### PR TITLE
Fixes for master

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -58,7 +58,7 @@ RAUC_BUNDLE_BUILD       ??= "${DATETIME}"
 RAUC_BUNDLE_BUILD[vardepsexclude] = "DATETIME"
 
 # Create dependency list from images
-do_fetch[depends] = "${@' '.join([d.getVar(image, True) + ":do_build" for image in \
+do_fetch[depends] = "${@' '.join([d.getVar(image, True) + ":do_image_complete" for image in \
     ['RAUC_SLOT_' + slot for slot in d.getVar('RAUC_BUNDLE_SLOTS', True).split()]])}"
 
 S = "${WORKDIR}"

--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -74,7 +74,7 @@ python __anonymous () {
         bb.fatal("'RAUC_CERT_FILE' not set. Please set to a valid certificate file location.")
 }
 
-DEPENDS = "rauc-native"
+DEPENDS = "rauc-native squashfs-tools-native"
 
 python do_fetch() {
     import shutil

--- a/recipes-core/rauc/rauc.inc
+++ b/recipes-core/rauc/rauc.inc
@@ -2,7 +2,7 @@ DESCRIPTION = "RAUC update controller for host and target"
 HOMEPAGE = "https://github.com/rauc/rauc"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
-DEPENDS = "openssl glib-2.0"
+DEPENDS = "openssl glib-2.0 glib-2.0-native"
 
 inherit autotools pkgconfig gettext
 


### PR DESCRIPTION
This patchset fixes building a bundle with current oe-core/Yocto master branches: mostly related to missing/wrong dependencies likely triggered by recent upstream changes that enable recipe specific sysroots.