### PR TITLE
classes: bundle: let RAUC_IMAGE_FSTYPE default to IMAGE_FSTYPES[0]

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -36,7 +36,7 @@ LICENSE = "MIT"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-RAUC_IMAGE_FSTYPE ?= "ext4"
+RAUC_IMAGE_FSTYPE ??= "${@(d.getVar('IMAGE_FSTYPES', True) or "").split()[0]}"
 
 do_fetch[cleandirs] = "${S}"
 do_patch[noexec] = "1"


### PR DESCRIPTION
This is a better estimate then unconditionally setting default to ext4.

Also make it a weak default to ease overwriting it from custom layers.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>