### PR TITLE
add support for RAUC hawkBit client

### DIFF
--- a/README
+++ b/README
@@ -20,6 +20,12 @@ This layer depends on:
   layers: meta-oe
   branch: master
 
+For rauc-hawkbit client:
+
+  URI: git://git.yoctoproject.org/meta-oe
+  layers: meta-python
+  branch: master
+
 
 Patches
 =======
@@ -35,8 +41,9 @@ Table of Contents
   I. Adding the rauc layer to your build
  II. Building RAUC
 III. Adding the RAUC update framework to your device
- IV. Configure Custom Kernel
-  V. References
+ IV. Building RAUC hawkBit Client
+  V. Configure Custom Kernel
+ VI. References
 
 
 I. Adding the rauc Layer to Your Build
@@ -108,8 +115,16 @@ read the notes in the bundle.bbclass file.
 
   bitbake my-bundle-recipe
 
+IV. Building RAUC hawkBit Client
+================================
 
-IV. Configure Custom Kernel
+To build the rauc-hawkbit client that allows interfacing between RAUC and a
+hawkBit deployment server, simply add `rauc-hawkbit` package to your systems
+image recipe:
+
+  IMAGE_INSTALL_append = " rauc-hawkbit"
+
+V. Configure Custom Kernel
 ===========================
 
 In order to use RAUC on your system, the kernel must support SquashFS and loop
@@ -121,7 +136,7 @@ make sure that the options in `recipes-kernel/linux/linux-yocto/rauc.cfg` are
 enabled in your configuration, too.
 
 
-V. References
-=============
+VI. References
+==============
 
 [1] RAUC user documentation http://rauc.readthedocs.io/en/latest/

--- a/recipes-devtools/python-aiohttp/python3-aiohttp_2.0.7.bb
+++ b/recipes-devtools/python-aiohttp/python3-aiohttp_2.0.7.bb
@@ -1,0 +1,31 @@
+SUMMARY = "HTTP client/server for asyncio"
+HOMEPAGE = "http://aiohttp.readthedocs.org/"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=60dd5a575c9bd4339411bdef4a702d46"
+
+SRC_URI[md5sum] = "1ae6e69655389cbd0c81346492267314"
+SRC_URI[sha256sum] = "76bfd47ee7fbda115cff486c3944fcb237ecbf6195bf2943fae74052fb40c4fe"
+
+# make clean calls python instead of python3, which makes setup.py fail
+CLEANBROKEN = "1"
+
+PYPI_PACKAGE = "aiohttp"
+
+# python3-misc is needed for the operator module
+# python3-netserver is needed for the cgi module
+RDEPENDS_${PN} = "python3-asyncio python3-async-timeout python3-chardet python3-json python3-multiprocessing python3-misc python3-netserver python3-multidict python3-yarl"
+
+inherit pypi setuptools3
+
+do_install_append() {
+    rm ${D}${libdir}/python3.*/site-packages/aiohttp/__pycache__/*
+    rmdir ${D}${libdir}/python3.*/site-packages/aiohttp/__pycache__
+    rm ${D}${libdir}/python3.*/site-packages/aiohttp/*.c
+}
+
+PACKAGES =+ "${PN}-extensions"
+
+FILES_${PN}-extensions = "\
+    ${libdir}/python3.*/site-packages/aiohttp/*.pyx \
+    ${libdir}/python3.*/site-packages/aiohttp/*.so \
+"

--- a/recipes-devtools/python-aiohttp/python3-async-timeout_1.4.0.bb
+++ b/recipes-devtools/python-aiohttp/python3-async-timeout_1.4.0.bb
@@ -1,0 +1,11 @@
+SUMMARY = "Timeout context manager for asyncio programs"
+HOMEPAGE = "https://github.com/aio-libs/async_timeout/"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
+
+inherit pypi setuptools3
+
+SRC_URI[md5sum] = "05f59e88d72ba3da099f8785bf49e97c"
+SRC_URI[sha256sum] = "983891535b1eca6ba82b9df671c8abff53c804fce3fa630058da5bbbda500340"
+
+DEPENDS = "python3-pytest-runner-native python3"

--- a/recipes-devtools/python-gbulb/python3-gbulb_0.5.3.bb
+++ b/recipes-devtools/python-gbulb/python3-gbulb_0.5.3.bb
@@ -1,0 +1,14 @@
+SUMMARY = "GLib event loop for tulip (PEP 3156)"
+HOMEPAGE = "http://github.com/nathan-hoad/gbulb"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://PKG-INFO;md5=ceb5c94bee9ee3df2a39952beeb0bc83"
+
+SRC_URI[md5sum] = "424fea3695a8ff6bd39a8cbadbde008b"
+SRC_URI[sha256sum] = "00e92fda2ed4ee8c1a48b423f4f7a387dbc288d4bc36f5a8d0c8ac2759c47ea5"
+
+PYPI_PACKAGE = "gbulb"
+
+# python3-misc is needed for the signal module
+RDEPENDS_${PN} = "python3-pygobject python3-asyncio python3-misc"
+
+inherit pypi setuptools3

--- a/recipes-devtools/python/python3-multidict_3.2.0.bb
+++ b/recipes-devtools/python/python3-multidict_3.2.0.bb
@@ -1,0 +1,9 @@
+SUMMARY = "Multidicts are useful for working with HTTP headers, URL query args etc."
+HOMEPAGE = "https://github.com/aio-libs/multidict/"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e74c98abe0de8f798ca609137f9cef4a"
+
+inherit pypi setuptools3
+
+SRC_URI[md5sum] = "a01da31ca1855557a1b2e053c933af2f"
+SRC_URI[sha256sum] = "e27a7a95317371c15ecda7206f6e8c144f10a337bb2c3e61b5176deafbb88cb2"

--- a/recipes-devtools/python/python3-yarl_0.11.0.bb
+++ b/recipes-devtools/python/python3-yarl_0.11.0.bb
@@ -1,0 +1,11 @@
+SUMMARY = "Yet another URL library"
+HOMEPAGE = "https://github.com/aio-libs/yarl/"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=22522b8f7ca5b78025a4fb540c948907"
+
+inherit pypi setuptools3
+
+SRC_URI[md5sum] = "a5a21f6ba05b62d34a32b3bbe50493bf"
+SRC_URI[sha256sum] = "51b92ef78e322cb2c93839c404de5ae33e852cab665fc99652fa89d7ab16e761"
+
+RDEPENDS_${PN} = "${PYTHON_PN}-multidict"

--- a/recipes-support/rauc-hawkbit/rauc-hawkbit_git.bb
+++ b/recipes-support/rauc-hawkbit/rauc-hawkbit_git.bb
@@ -1,0 +1,15 @@
+LICENSE = "LGPLv2.1"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
+
+SUMMARY = "hawkBit client for RAUC"
+
+SRC_URI = "git://github.com/rauc/rauc-hawkbit.git;protocol=https"
+
+PV = "0.1.0+git${SRCPV}"
+SRCREV = "79421c1c0b1480da70c426f782585fa66416eed0"
+
+S = "${WORKDIR}/git"
+
+inherit setuptools3
+
+RDEPENDS_${PN} += "python3-aiohttp python3-gbulb"


### PR DESCRIPTION
This adds recipes for building the (just published) [rauc-hawkbit](https://github.com/rauc/rauc-hawkbit) client.

This is an initial version of the recipes, neither heavily tested nor equipped with any service startup infrastructure. Feel free to test it, provide feedback and improve it.

In order to build it, you also need to enable meta-openembedded/meta-python and meta-openembedded/meta-oe in you bblayers.conf.