### PR TITLE
classes: bundle: use weak defaults assignment for key files

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -63,8 +63,8 @@ do_fetch[depends] = "${@' '.join([d.getVar(image, True) + ":do_image_complete" f
 
 S = "${WORKDIR}"
 
-RAUC_KEY_FILE ?= ""
-RAUC_CERT_FILE ?= ""
+RAUC_KEY_FILE ??= ""
+RAUC_CERT_FILE ??= ""
 
 python __anonymous () {
     if not d.getVar('RAUC_KEY_FILE', True):


### PR DESCRIPTION
Use weak default assignment when setting RAUC_{KEY,CERT}_FILE to allow
other layers to set default values for key files that can be overridden
in e.g. local.conf when doing release builds.