### PR TITLE
rauc: allow override CA certificate file entry in SRC_URI

### DIFF
--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -1,6 +1,7 @@
+RAUC_KEYRING_FILE ??= "file://ca.cert.pem"
 SRC_URI_append = " \
   file://system.conf \
-  file://ca.cert.pem \
+  ${RAUC_KEYRING_FILE} \
   file://rauc-mark-good.service \
   "
 


### PR DESCRIPTION
Append files to the rauc recipe from other layers might need to use a
CA certificate external to the build directory, in which case it should
be possible to use an absolute path in the SRC_URI.

In case of certificate files not named ca.cert.pem as expected by the
rauc recipe, append files can use the `downloadfilename`, e.g.

RAUC_CA_FILE = "file://path/to/our/ca.crt;downloadfilename=ca.cert.pem"