### PR TITLE
rauc-native: use DEPLOY_DIR_TOOLS

### DIFF
--- a/recipes-core/rauc/rauc-native_git.bb
+++ b/recipes-core/rauc/rauc-native_git.bb
@@ -5,9 +5,9 @@ inherit native deploy
 do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
 
 do_deploy() {
-    install -d ${DEPLOYDIR}
-    install -m 0755 ${B}/rauc ${DEPLOYDIR}/rauc-${PV}
-    ln -sf rauc-${PV} ${DEPLOYDIR}/rauc
+    install -d ${DEPLOY_DIR_TOOLS}
+    install -m 0755 ${B}/rauc ${DEPLOY_DIR_TOOLS}/rauc-${PV}
+    ln -sf rauc-${PV} ${DEPLOY_DIR_TOOLS}/rauc
 }
 
 addtask deploy before do_package after do_install


### PR DESCRIPTION
switching machines result in

ERROR: rauc-native-0+gitAUTOINC+3867722b8d-r9 do_deploy: The recipe
rauc-native is trying to install files into a shared area when those
files already exist. Those files and their manifest location are:
   build/deploy/tools/rauc-0+gitAUTOINC+3867722b8d
 Matched in b'manifest-MACHINE1-rauc-native.deploy'
 build/deploy/tools/rauc
 Matched in b'manifest-MACHINE2-rauc-native.deploy'
Please verify which recipe should provide the above files.

Using DEPLOY_DIR_TOOLS in do_deploy fixes this.

Signed-off-by: Jan Remmet <j.remmet@phytec.de>