### PR TITLE
rauc-native: append datetime to tooldir filename

### DIFF
--- a/recipes-core/rauc/rauc-native_git.bb
+++ b/recipes-core/rauc/rauc-native_git.bb
@@ -2,12 +2,15 @@ require rauc-git.inc
 
 inherit native deploy
 
+RAUC_TOOL_BASENAME = "rauc-${PV}-${DATETIME}"
+RAUC_TOOL_BASENAME[vardepsexclude] = "DATETIME"
+
 do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
 
 do_deploy() {
     install -d ${DEPLOY_DIR_TOOLS}
-    install -m 0755 ${B}/rauc ${DEPLOY_DIR_TOOLS}/rauc-${PV}
-    ln -sf rauc-${PV} ${DEPLOY_DIR_TOOLS}/rauc
+    install -m 0755 ${B}/rauc ${DEPLOY_DIR_TOOLS}/${RAUC_TOOL_BASENAME}
+    ln -sf ${RAUC_TOOL_BASENAME} ${DEPLOY_DIR_TOOLS}/rauc
 }
 
 addtask deploy before do_package after do_install


### PR DESCRIPTION
When rauc-native is rebuilt due to changes others than ${PV}, the
do_deploy step fails because of ${DEPLOY_DIR_TOOLS}/rauc-${PV} already
being present.

Fix this by appending ${DATETIME} to the install filename, and avoid
basehash/taskhash mismatches by excluding ${DATETIME} from the
basehash/taskhash.

Signed-off-by: Martin Hundebøll <mnhu@prevas.dk>