### PR TITLE
Morty update

### DIFF
--- a/README
+++ b/README
@@ -39,7 +39,7 @@ III. Adding the RAUC update framework to your device
   V. References
 
 
-I. Adding the rauc Layer to your Build
+I. Adding the rauc Layer to Your Build
 ======================================
 
 In order to use this layer, you need to make the build system aware of
@@ -67,7 +67,8 @@ If you only intend to build the RAUC host tool, you may simply run
 
 This will place the rauc binary at tmp/deploy/tools/rauc.
 
-III. Adding the RAUC update framework to your device
+
+III. Adding the RAUC Update Framework to Your Device
 ====================================================
 
 To prepare your device for using RAUC as its update handler,
@@ -107,6 +108,7 @@ read the notes in the bundle.bbclass file.
 
   bitbake my-bundle-recipe
 
+
 IV. Configure Custom Kernel
 ===========================
 
@@ -115,9 +117,9 @@ mounts. For the standard yocto kernel, the meta-rauc layer provides a kernel
 configuration fragment that enables the config options required for this.
 
 If you build your own kernel with a full custom `defconfig` file, you have to
-make sure that you have the options enabled in
-`recipes-kernel/linux/linux-yocto/rauc.cfg` are enabled in your configuration,
-too.
+make sure that the options in `recipes-kernel/linux/linux-yocto/rauc.cfg` are
+enabled in your configuration, too.
+
 
 V. References
 =============

--- a/README
+++ b/README
@@ -95,11 +95,11 @@ configuration.
   RAUC_BUNDLE_SLOTS = "rootfs"
   RAUC_SLOT_rootfs = "my-rootfs-recipe"
 
-  RAUC_KEY_FILE="path/to/development-1.key.pem"
-  RAUC_CERT_FILE="path/to/development-1.key.pem"
+  RAUC_KEY_FILE = "path/to/development-1.key.pem"
+  RAUC_CERT_FILE = "path/to/development-1.cert.pem"
 
 For information on how to generate and use the key and certificate files,
-please refert to the RAUC user documentation [1].
+please refer to the RAUC user documentation [1].
 
 For a more detailed explanation on the required and available variables,
 read the notes in the bundle.bbclass file.

--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -58,7 +58,7 @@ RAUC_BUNDLE_BUILD       ??= "${DATETIME}"
 RAUC_BUNDLE_BUILD[vardepsexclude] = "DATETIME"
 
 # Create dependency list from images
-do_fetch[depends] = "${@' '.join([d.getVar(image, True) + ":do_image_complete" for image in \
+do_fetch[depends] = "${@' '.join([d.getVar(image, True) + ":do_build" for image in \
     ['RAUC_SLOT_' + slot for slot in d.getVar('RAUC_BUNDLE_SLOTS', True).split()]])}"
 
 S = "${WORKDIR}"

--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -24,7 +24,7 @@
 #
 #   RAUC_SLOT_dtb ?= linux-yocto
 #   RAUC_SLOT_dtb[type] ?= "file"
-#   RAUC_SLOT_dtb[file] ?= "am335x-bone.dtb"
+#   RAUC_SLOT_dtb[file] ?= "${MACHINE}.dtb"
 #
 #
 # Additionally you need to provide a certificate and a key file
@@ -121,7 +121,7 @@ python do_fetch() {
         elif imgtype == 'kernel':
             # TODO: Add image type support
             if slotflags and 'file' in slotflags:
-                imgsource = "%s" % slotflags.get('file')
+                imgsource = d.getVarFlag('RAUC_SLOT_%s' % slot, 'file', True)
             else:
                 imgsource = "%s-%s.bin" % ("zImage", machine)
             imgname = "%s.%s" % (imgsource, "img")
@@ -131,7 +131,7 @@ python do_fetch() {
             imgname = imgsource
         elif imgtype == 'file':
             if slotflags and 'file' in slotflags:
-                imgsource = "%s" % slotflags.get('file')
+                imgsource = d.getVarFlag('RAUC_SLOT_%s' % slot, 'file', True)
             else:
                 raise bb.build.FuncFailed('Unknown file for slot: %s' % slot)
             imgname = "%s.%s" % (imgsource, "img")

--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -58,7 +58,7 @@ RAUC_BUNDLE_BUILD       ??= "${DATETIME}"
 RAUC_BUNDLE_BUILD[vardepsexclude] = "DATETIME"
 
 # Create dependency list from images
-do_fetch[depends] = "${@' '.join([d.getVar(image, True) + ":do_build" for image in \
+do_fetch[depends] = "${@' '.join([d.getVar(image, True) + ":do_image_complete" for image in \
     ['RAUC_SLOT_' + slot for slot in d.getVar('RAUC_BUNDLE_SLOTS', True).split()]])}"
 
 S = "${WORKDIR}"

--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -63,8 +63,8 @@ do_fetch[depends] = "${@' '.join([d.getVar(image, True) + ":do_image_complete" f
 
 S = "${WORKDIR}"
 
-RAUC_KEY_FILE ?= ""
-RAUC_CERT_FILE ?= ""
+RAUC_KEY_FILE ??= ""
+RAUC_CERT_FILE ??= ""
 
 python __anonymous () {
     if not d.getVar('RAUC_KEY_FILE', True):

--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -36,7 +36,7 @@ LICENSE = "MIT"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-RAUC_IMAGE_FSTYPE ?= "ext4"
+RAUC_IMAGE_FSTYPE ??= "${@(d.getVar('IMAGE_FSTYPES', True) or "").split()[0]}"
 
 do_fetch[cleandirs] = "${S}"
 do_patch[noexec] = "1"

--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -74,7 +74,7 @@ python __anonymous () {
         bb.fatal("'RAUC_CERT_FILE' not set. Please set to a valid certificate file location.")
 }
 
-DEPENDS = "rauc-native"
+DEPENDS = "rauc-native squashfs-tools-native"
 
 python do_fetch() {
     import shutil

--- a/recipes-bsp/dt-utils/dt-utils_2016.12.0.bb
+++ b/recipes-bsp/dt-utils/dt-utils_2016.12.0.bb
@@ -1,4 +1,0 @@
-require dt-utils.inc
-
-SRC_URI[md5sum] = "9901cfc6cf6482af1c41255ea8dd418e"
-SRC_URI[sha256sum] = "b1d1853418bd8dac310518b214cc4bd34728a2dd7602e194099c5d157c744617"

--- a/recipes-bsp/dt-utils/dt-utils_2017.03.0.bb
+++ b/recipes-bsp/dt-utils/dt-utils_2017.03.0.bb
@@ -1,0 +1,4 @@
+require dt-utils.inc
+
+SRC_URI[md5sum] = "f7c6790358e2925654fd8efa8313768d"
+SRC_URI[sha256sum] = "a70a13ba9cbc93b6571622e78ba3aed78249856d544bfde55d67b3745767bcaf"

--- a/recipes-core/rauc/nativesdk-rauc_0.1.1.bb
+++ b/recipes-core/rauc/nativesdk-rauc_0.1.1.bb
@@ -1,0 +1,3 @@
+require rauc-0.1.1.inc
+
+inherit nativesdk

--- a/recipes-core/rauc/rauc-0.1.1.inc
+++ b/recipes-core/rauc/rauc-0.1.1.inc
@@ -1,0 +1,6 @@
+require rauc.inc
+
+SRC_URI = "https://github.com/rauc/rauc/releases/download/v${PV}/rauc-${PV}.tar.xz"
+
+SRC_URI[md5sum] = "4457d4d98efb83399ff45d36b31b3e3f"
+SRC_URI[sha256sum] = "d2901d493f1d3210aef6411e83b02edac3a678d6d825d71a1c61b5b6afc7e478"

--- a/recipes-core/rauc/rauc-git.inc
+++ b/recipes-core/rauc/rauc-git.inc
@@ -6,7 +6,7 @@ SRC_URI = " \
   git://github.com/rauc/rauc.git;protocol=https \
   "
 
-PV = "0+git${SRCPV}"
+PV = "0.1+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-SRCREV = "3867722b8d64c43765e2d04f346dd612c02ad137"
+SRCREV = "33fe5ab4bc8c364b666b7332c2f3ec6fc095b7a2"

--- a/recipes-core/rauc/rauc-git.inc
+++ b/recipes-core/rauc/rauc-git.inc
@@ -6,7 +6,7 @@ SRC_URI = " \
   git://github.com/rauc/rauc.git;protocol=https \
   "
 
-PV = "0.1+git${SRCPV}"
+PV = "0.1.1+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-SRCREV = "33fe5ab4bc8c364b666b7332c2f3ec6fc095b7a2"
+SRCREV = "4b6453e8678a48aa793c41871e3bfcfdbafce881"

--- a/recipes-core/rauc/rauc-native_0.1.1.bb
+++ b/recipes-core/rauc/rauc-native_0.1.1.bb
@@ -1,0 +1,13 @@
+require rauc-0.1.1.inc
+
+inherit native deploy
+
+do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
+
+do_deploy() {
+    install -d ${DEPLOYDIR}
+    install -m 0755 ${B}/rauc ${DEPLOYDIR}/rauc-${PV}
+    ln -sf rauc-${PV} ${DEPLOYDIR}/rauc
+}
+
+addtask deploy before do_package after do_install

--- a/recipes-core/rauc/rauc-native_git.bb
+++ b/recipes-core/rauc/rauc-native_git.bb
@@ -5,9 +5,9 @@ inherit native deploy
 do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
 
 do_deploy() {
-    install -d ${DEPLOYDIR}
-    install -m 0755 ${B}/rauc ${DEPLOYDIR}/rauc-${PV}
-    ln -sf rauc-${PV} ${DEPLOYDIR}/rauc
+    install -d ${DEPLOY_DIR_TOOLS}
+    install -m 0755 ${B}/rauc ${DEPLOY_DIR_TOOLS}/rauc-${PV}
+    ln -sf rauc-${PV} ${DEPLOY_DIR_TOOLS}/rauc
 }
 
 addtask deploy before do_package after do_install

--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -1,8 +1,9 @@
-RAUC_KEYRING_FILE ??= "file://ca.cert.pem"
+RAUC_KEYRING_FILE ??= "ca.cert.pem"
+RAUC_KEYRING_URI ??= "file://${RAUC_KEYRING_FILE}"
 
 SRC_URI_append = " \
   file://system.conf \
-  ${RAUC_KEYRING_FILE} \
+  ${RAUC_KEYRING_URI} \
   file://rauc-mark-good.service \
   "
 
@@ -23,11 +24,11 @@ do_install () {
         install -m 0644 ${WORKDIR}/system.conf ${D}${sysconfdir}/rauc/system.conf
 
         # Warn if CA file was not overwritten
-        if ! grep -q "^[^#]" ${WORKDIR}/ca.cert.pem; then
-                bbwarn "Please overwrite example ca.cert.pem with a project specific one!"
+        if ! grep -q "^[^#]" ${WORKDIR}/${RAUC_KEYRING_FILE}; then
+                bbwarn "Please overwrite example ca.cert.pem with a project specific one, or set the RAUC_KEYRING_FILE varibale with your file!"
         fi
         install -d ${D}${sysconfdir}/rauc/
-        install -m 0644 ${WORKDIR}/ca.cert.pem ${D}${sysconfdir}/rauc/
+        install -m 0644 ${WORKDIR}/${RAUC_KEYRING_FILE} ${D}${sysconfdir}/rauc/
 
         install -d ${D}${systemd_unitdir}/system/
         install -m 0644 ${WORKDIR}/rauc-mark-good.service ${D}${systemd_unitdir}/system/

--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -1,6 +1,8 @@
+RAUC_KEYRING_FILE ??= "file://ca.cert.pem"
+
 SRC_URI_append = " \
   file://system.conf \
-  file://ca.cert.pem \
+  ${RAUC_KEYRING_FILE} \
   file://rauc-mark-good.service \
   "
 

--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -1,0 +1,44 @@
+SRC_URI_append = " \
+  file://system.conf \
+  file://ca.cert.pem \
+  file://rauc-mark-good.service \
+  "
+
+SYSTEMD_PACKAGES += "${PN}-mark-good"
+SYSTEMD_SERVICE_${PN}-mark-good = "rauc-mark-good.service"
+
+inherit systemd
+
+do_install () {
+	autotools_do_install
+
+        # Create rauc config dir
+        # Warn if system configuration was not overwritten
+        if ! grep -q "^[^#]" ${WORKDIR}/system.conf; then
+                bbwarn "Please overwrite example system.conf with a project specific one!"
+        fi
+        install -d ${D}${sysconfdir}/rauc
+        install -m 0644 ${WORKDIR}/system.conf ${D}${sysconfdir}/rauc/system.conf
+
+        # Warn if CA file was not overwritten
+        if ! grep -q "^[^#]" ${WORKDIR}/ca.cert.pem; then
+                bbwarn "Please overwrite example ca.cert.pem with a project specific one!"
+        fi
+        install -d ${D}${sysconfdir}/rauc/
+        install -m 0644 ${WORKDIR}/ca.cert.pem ${D}${sysconfdir}/rauc/
+
+        install -d ${D}${systemd_unitdir}/system/
+        install -m 0644 ${WORKDIR}/rauc-mark-good.service ${D}${systemd_unitdir}/system/
+        sed -i -e 's!@BINDIR@!${bindir}!g' ${D}${systemd_unitdir}/system/*.service
+}
+
+PACKAGES =+ "${PN}-mark-good"
+
+RDEPENDS_${PN} += "${@bb.utils.contains("PREFERRED_PROVIDER_virtual/bootloader", "barebox", "dt-utils-barebox-state", "",d)}"
+RDEPENDS_${PN} += "${@bb.utils.contains("PREFERRED_PROVIDER_virtual/bootloader", "u-boot", "u-boot-fw-utils", "",d)}"
+
+RRECOMMENDS_${PN}_append = " mtd-utils ${PN}-mark-good"
+
+FILES_${PN}-mark-good = "${systemd_unitdir}/system/rauc-mark-good.service"
+
+PACKAGECONFIG ??= "service network json"

--- a/recipes-core/rauc/rauc.inc
+++ b/recipes-core/rauc/rauc.inc
@@ -2,7 +2,7 @@ DESCRIPTION = "RAUC update controller for host and target"
 HOMEPAGE = "https://github.com/rauc/rauc"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
-DEPENDS = "openssl glib-2.0"
+DEPENDS = "openssl glib-2.0 glib-2.0-native"
 
 inherit autotools pkgconfig gettext
 

--- a/recipes-core/rauc/rauc_0.1.1.bb
+++ b/recipes-core/rauc/rauc_0.1.1.bb
@@ -1,2 +1,2 @@
-require rauc-git.inc
+require rauc-0.1.1.inc
 require rauc-target.inc

--- a/scripts/README
+++ b/scripts/README
@@ -1,7 +1,7 @@
 Generate Testing Certificate
 ----------------------------
 
-The script `openssl-ca.sh` allows you to create a certifikate and key that you
+The script `openssl-ca.sh` allows you to create a certificate and key that you
 can use for a test-setup of RAUC.
 
 To generate the required files, execute
@@ -11,7 +11,7 @@ To generate the required files, execute
 This will generate a folder `openssl-ca/` that contains the generated openssl
 configuration file and a development certificate and key.
 
-To use them in you BSP to in order to sign and verify bundles, you have to:
+To use them in your BSP in order to sign and verify bundles, you have to:
 
 1) Make the target rauc package use the generated keyring file:
 


### PR DESCRIPTION
Maybe we can merge some newer commits also to morty? Unfortunately we have a older morty based BSP but want to use the meta-rauc layer.
meta-rauc master fails with "non-existent task do_image_complete".
Reverting commit 823cdd6 ("bundle.bbclass: depend on an earlier task for images") fixes this and newer patches like rauc-0.1.1 works.
Tested on morty