### PR TITLE
classes: bundle: do not check for RAUC_KEY_FILE during parsing

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -74,14 +74,6 @@ S = "${WORKDIR}/bundle"
 RAUC_KEY_FILE ??= ""
 RAUC_CERT_FILE ??= ""
 
-python __anonymous () {
-    if not d.getVar('RAUC_KEY_FILE'):
-        bb.fatal("'RAUC_KEY_FILE' not set. Please set to a valid key file location.")
-
-    if not d.getVar('RAUC_CERT_FILE'):
-        bb.fatal("'RAUC_CERT_FILE' not set. Please set to a valid certificate file location.")
-}
-
 DEPENDS = "rauc-native squashfs-tools-native"
 
 def write_manifest(d):
@@ -185,6 +177,14 @@ BUNDLE_NAME[vardepsexclude] = "DATETIME"
 BUNDLE_LINK_NAME = "${BUNDLE_BASENAME}-${MACHINE}"
 
 do_bundle() {
+	if [ -z "${RAUC_KEY_FILE}" ]; then
+		bbfatal "'RAUC_KEY_FILE' not set. Please set to a valid key file location."
+	fi
+
+	if [ -z "${RAUC_CERT_FILE}" ]; then
+		bbfatal "'RAUC_CERT_FILE' not set. Please set to a valid certificate file location."
+	fi
+
 	if [ -e ${B}/bundle.raucb ]; then
 		rm ${B}/bundle.raucb
 	fi


### PR DESCRIPTION
If the check is performed by `python __anonymous()` function, the test
will always be executed right after parsing the recipe.
The result of this is that when not having `RAUC_KEY_FILE`/`RAUC_CERT_FILE`
set, every bitbake invocation will fail, no matter which recipe we gonna
build.

A this is a very bad behavior, we move the check to where it is really
needed: At the beginning of the `do_bundle()` task, right before invoking
RAUC to actually build the bundle.

This way we will abort with a helpful message during do_bundle() task
(when building a RAUC bundle from an non-prepared environment), while
still being able to build all other non-RAUC-related packages without
errors.

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>