### PR TITLE
conf/layer.conf: specify LAYERDEPENDS for rauc layer

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,3 +8,5 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "rauc"
 BBFILE_PATTERN_rauc = "^${LAYERDIR}/"
 BBFILE_PRIORITY_rauc = "6"
+
+LAYERDEPENDS_rauc = "core openembedded-layer meta-python"


### PR DESCRIPTION
This will error with a helpful message if one of the mandatory layers
(oe-core, meta-oe, meta-pythonA) does not exist instead of failing, for
examples, for a missing class or recipe.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>