### PR TITLE
depend on do_deploy for 'file'-SLOTS.

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -63,7 +63,7 @@ python __anonymous() {
         slotflags = d.getVarFlags('RAUC_SLOT_%s' % slot)
         imgtype = slotflags.get('type') if slotflags else None
         image = d.getVar('RAUC_SLOT_%s' % slot)
-        if imgtype == 'kernel' or imgtype == 'boot':
+        if imgtype == 'kernel' or imgtype == 'boot' or imgtype == 'file':
             d.appendVarFlag('do_unpack', 'depends', ' ' + image + ':do_deploy')
         else:
             d.appendVarFlag('do_unpack', 'depends', ' ' + image + ':do_image_complete')

--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -63,10 +63,10 @@ python __anonymous() {
         slotflags = d.getVarFlags('RAUC_SLOT_%s' % slot)
         imgtype = slotflags.get('type') if slotflags else None
         image = d.getVar('RAUC_SLOT_%s' % slot)
-        if imgtype == 'kernel' or imgtype == 'boot' or imgtype == 'file':
-            d.appendVarFlag('do_unpack', 'depends', ' ' + image + ':do_deploy')
-        else:
+        if imgtype == 'image':
             d.appendVarFlag('do_unpack', 'depends', ' ' + image + ':do_image_complete')
+        else:
+            d.appendVarFlag('do_unpack', 'depends', ' ' + image + ':do_deploy')
 }
 
 S = "${WORKDIR}/bundle"


### PR DESCRIPTION
I assume that `file` is not intended to be an image (rootfs)?

If that assumptions is correct, the provided patch should be applied.

Signed-off-by: Leif Middelschulte <leif.middelschulte@gmail.com>