### PR TITLE
Add support for building RAUC with casync support

### DIFF
--- a/README
+++ b/README
@@ -26,6 +26,11 @@ For rauc-hawkbit client:
   layers: meta-python
   branch: master
 
+For casync:
+
+  URI: git://git.yoctoproject.org/meta-oe
+  layers: meta-filesystems
+  branch: master
 
 Patches
 =======

--- a/recipes-casync/casync/casync_git.bb
+++ b/recipes-casync/casync/casync_git.bb
@@ -1,0 +1,23 @@
+SUMMARY = "Content-Addressable Data Synchronization Tool"
+HOMEPAGE = "https://github.com/systemd/casync"
+LICENSE = "LGPLv2.1"
+LIC_FILES_CHKSUM = "file://LICENSE.LGPL2.1;md5=4fbd65380cdd255951079008b364516c"
+
+DEPENDS = "xz curl openssl acl fuse zstd"
+DEPENDS_append_class-target = " udev"
+
+SRCREV = "a755da21d3ba5d9cbb002dfc86a3ab0d46b82176"
+PV = "2+git${SRCPV}"
+
+SRC_URI = " \
+    git://github.com/systemd/casync.git;protocol=https \
+    "
+
+S = "${WORKDIR}/git"
+
+inherit meson
+
+EXTRA_OEMESON += "-Dselinux=false -Dman=false"
+EXTRA_OEMESON_append_class-native = " -Dudev=false"
+
+BBCLASSEXTEND = "native"

--- a/recipes-support/zstd/zstd_git.bb
+++ b/recipes-support/zstd/zstd_git.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Zstandard - Fast real-time compression algorithm"
+HOMEPAGE = "http://www.zstd.net"
+LICENSE = "BSD & GPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c7f0b161edbe52f5f345a3d1311d0b32 \
+                    file://contrib/linux-kernel/COPYING;md5=39bba7d2cf0ba1036f2a6e2be52fe3f0"
+SRCREV = "f3a8bd553a865c59f1bd6e1f68bf182cf75a8f00"
+PV = "1.33+git${SRCPV}"
+
+SRC_URI = "git://github.com/facebook/zstd.git;protocol=https"
+
+S = "${WORKDIR}/git"
+
+EXTRA_OECMAKE_append = " -DTHREADS_PTHREAD_ARG=0"
+
+do_install() {
+    oe_runmake DESTDIR=${D} install
+}
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
This adds basic OE integration for casync, zstd compression lib and adds the RAUC casync support patches as posted [here](https://github.com/rauc/rauc/pull/217).