### PR TITLE
classes: bundle: run rauc with debug output enabled

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -189,6 +189,7 @@ do_bundle() {
 		rm ${B}/bundle.raucb
 	fi
 	${STAGING_DIR_NATIVE}${bindir}/rauc bundle \
+		--debug \
 		--cert=${RAUC_CERT_FILE} \
 		--key=${RAUC_KEY_FILE} \
 		${S} \


### PR DESCRIPTION
Being more verbose in the output might ease analyzing possible issues in
the Yocto log files.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>