### PR TITLE
make the BUNDLE_NAME and the dependent variables overridable

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -170,11 +170,11 @@ do_unpack_append() {
         os.chmod(dsthook, st.st_mode | stat.S_IEXEC)
 }
 
-BUNDLE_BASENAME = "${PN}"
-BUNDLE_NAME = "${BUNDLE_BASENAME}-${MACHINE}-${DATETIME}"
+BUNDLE_BASENAME ??= "${PN}"
+BUNDLE_NAME ??= "${BUNDLE_BASENAME}-${MACHINE}-${DATETIME}"
 # Don't include the DATETIME variable in the sstate package sigantures
 BUNDLE_NAME[vardepsexclude] = "DATETIME"
-BUNDLE_LINK_NAME = "${BUNDLE_BASENAME}-${MACHINE}"
+BUNDLE_LINK_NAME ??= "${BUNDLE_BASENAME}-${MACHINE}"
 
 do_bundle() {
 	if [ -z "${RAUC_KEY_FILE}" ]; then


### PR DESCRIPTION
In some use cases it is necessary to override the bundle name. Changed the value assignment to lowest priority, so that is in this use case cleaner.

Signed-off-by: Eugen Wiens <eugen.wiens@jumo.net>