### PR TITLE
add check if imgtype is set

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -63,6 +63,10 @@ python __anonymous() {
         slotflags = d.getVarFlags('RAUC_SLOT_%s' % slot)
         imgtype = slotflags.get('type') if slotflags else None
         image = d.getVar('RAUC_SLOT_%s' % slot)
+
+        if imgtype is None:
+            bb.fatal('Please specify the type of the RAUC_SLOT_' + slot + ': ' + image )
+
         if imgtype == 'image':
             d.appendVarFlag('do_unpack', 'depends', ' ' + image + ':do_image_complete')
         else:

--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -61,11 +61,8 @@ RAUC_BUNDLE_BUILD[vardepsexclude] = "DATETIME"
 python __anonymous() {
     for slot in (d.getVar('RAUC_BUNDLE_SLOTS') or "").split():
         slotflags = d.getVarFlags('RAUC_SLOT_%s' % slot)
-        imgtype = slotflags.get('type') if slotflags else None
+        imgtype = slotflags.get('type') if slotflags else 'image'
         image = d.getVar('RAUC_SLOT_%s' % slot)
-
-        if imgtype is None:
-            bb.fatal('Please specify the type of the RAUC_SLOT_' + slot + ': ' + image )
 
         if imgtype == 'image':
             d.appendVarFlag('do_unpack', 'depends', ' ' + image + ':do_image_complete')


### PR DESCRIPTION
in the case if the image type is not set, the behavior of the dependency can be wrong. Add fatal if the type is not set to prevent unexpected behavior.

Signed-off-by: Eugen Wiens <eugen.wiens@jumo.net>