### PR TITLE
added support for custom barebox image name

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -131,7 +131,7 @@ def write_manifest(d):
             if slotflags and 'file' in slotflags:
                 imgsource = d.getVarFlag('RAUC_SLOT_%s' % slot, 'file')
             else:
-                imgsource = imgsource = "%s" % ("barebox.img")
+                imgsource = "%s" % ("barebox.img")
             imgname = imgsource
         elif imgtype == 'file':
             if slotflags and 'file' in slotflags:

--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -21,6 +21,7 @@
 #   
 #   RAUC_SLOT_bootloader ?= "barebox"
 #   RAUC_SLOT_bootloader[type] ?= "boot"
+#   RAUC_SLOT_bootloader[file] ?= "barebox.img"
 #
 #   RAUC_SLOT_dtb ?= linux-yocto
 #   RAUC_SLOT_dtb[type] ?= "file"
@@ -127,8 +128,10 @@ def write_manifest(d):
                 imgsource = "%s-%s.bin" % ("zImage", machine)
             imgname = "%s.%s" % (imgsource, "img")
         elif imgtype == 'boot':
-            # TODO: adapt if barebox produces determinable output images
-            imgsource = "%s" % ("barebox.img")
+            if slotflags and 'file' in slotflags:
+                imgsource = d.getVarFlag('RAUC_SLOT_%s' % slot, 'file')
+            else:
+                imgsource = imgsource = "%s" % ("barebox.img")
             imgname = imgsource
         elif imgtype == 'file':
             if slotflags and 'file' in slotflags:


### PR DESCRIPTION
added selection of the image name with the slotflag 'file'. If the slotflag 'file' is not set, the default image name 'barebox.img' is used.

Signed-off-by: Eugen Wiens <eugen.wiens@jumo.net>