### PR TITLE
Rocko+rauc 0.3

### DIFF
--- a/recipes-core/rauc/nativesdk-rauc_0.3.bb
+++ b/recipes-core/rauc/nativesdk-rauc_0.3.bb
@@ -1,0 +1,3 @@
+require rauc-0.3.inc
+
+inherit nativesdk

--- a/recipes-core/rauc/rauc-0.3.inc
+++ b/recipes-core/rauc/rauc-0.3.inc
@@ -1,0 +1,6 @@
+require rauc.inc
+
+SRC_URI = "https://github.com/rauc/rauc/releases/download/v${PV}/rauc-${PV}.tar.xz"
+
+SRC_URI[md5sum] = "0e3fd03dbbe152fdbdca291007dcc53f"
+SRC_URI[sha256sum] = "dc01bfb08b1830376782f9a51cfec290171519267ab97cc909435da9ac6d6d98"

--- a/recipes-core/rauc/rauc-git.inc
+++ b/recipes-core/rauc/rauc-git.inc
@@ -10,3 +10,5 @@ PV = "0.3+git${SRCPV}"
 S = "${WORKDIR}/git"
 
 SRCREV = "419387685f1e5fb0d59aa21d0eb47ddae5120600"
+
+DEFAULT_PREFERENCE = "-1"

--- a/recipes-core/rauc/rauc-git.inc
+++ b/recipes-core/rauc/rauc-git.inc
@@ -1,12 +1,12 @@
 require rauc.inc
 
-PR = "r9"
+PR = "r0"
 
 SRC_URI = " \ 
   git://github.com/rauc/rauc.git;protocol=https \
   "
 
-PV = "0.1.1+git${SRCPV}"
+PV = "0.3+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-SRCREV = "4b6453e8678a48aa793c41871e3bfcfdbafce881"
+SRCREV = "419387685f1e5fb0d59aa21d0eb47ddae5120600"

--- a/recipes-core/rauc/rauc-native_0.3.bb
+++ b/recipes-core/rauc/rauc-native_0.3.bb
@@ -1,0 +1,13 @@
+require rauc-0.3.inc
+
+inherit native deploy
+
+do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
+
+do_deploy() {
+    install -d ${DEPLOYDIR}
+    install -m 0755 ${B}/rauc ${DEPLOYDIR}/rauc-${PV}
+    ln -sf rauc-${PV} ${DEPLOYDIR}/rauc
+}
+
+addtask deploy before do_package after do_install

--- a/recipes-core/rauc/rauc_0.3.bb
+++ b/recipes-core/rauc/rauc_0.3.bb
@@ -1,0 +1,2 @@
+require rauc-0.3.inc
+require rauc-target.inc


### PR DESCRIPTION
The first commit adds a recipe for [rauc v0.3](https://github.com/rauc/rauc/releases/tag/v0.3).

The second commit updates the provided `_git.bb` to point to the [0.3 revision](https://github.com/rauc/rauc/commit/419387685f1e5fb0d59aa21d0eb47ddae5120600).

Even though there is no `_0.1.bb` I left the `0_0.2.bb` there for users to set `PREFERED_VERSION_rauc = 0.2` in their `distro.conf`.