### PR TITLE
rauc-native_0.2: Use DEPLOY_DIR_TOOLS

### DIFF
--- a/recipes-core/rauc/rauc-native_0.2.bb
+++ b/recipes-core/rauc/rauc-native_0.2.bb
@@ -5,9 +5,9 @@ inherit native deploy
 do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
 
 do_deploy() {
-    install -d ${DEPLOYDIR}
-    install -m 0755 ${B}/rauc ${DEPLOYDIR}/rauc-${PV}
-    ln -sf rauc-${PV} ${DEPLOYDIR}/rauc
+    install -d ${DEPLOY_DIR_TOOLS}
+    install -m 0755 ${B}/rauc ${DEPLOY_DIR_TOOLS}/rauc-${PV}
+    ln -sf rauc-${PV} ${DEPLOY_DIR_TOOLS}/rauc
 }
 
 addtask deploy before do_package after do_install


### PR DESCRIPTION
Applying fix from 7f5c3e024747ec32f5b61c8aea8fd5fc4da152ed to rauc_native_0.2
also.

Signed-off-by: Kasper Revsbech <krev@triax.com>