### PR TITLE
conf: layer: set LAYERSERIES_COMPAT for this layer

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -16,3 +16,5 @@ LAYERRECOMMENDS_rauc = "meta-python"
 
 # meta-filesystems is needed to build cascync with fuse support (the default)
 LAYERRECOMMENDS_rauc += "meta-filesystems"
+
+LAYERSERIES_COMPAT_rauc = "sumo rocko"


### PR DESCRIPTION
Setting this variable is used since sumo to track layer compatibility
and active layer maintanance.
Setting this will prevent from utriggering a warning and is required for
Yocto Project Compatible version 2 standard.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>