### PR TITLE
rauc: rauc-target.inc: do not put mtd-utils in RRECOMMENDS by default

### DIFF
--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -40,7 +40,7 @@ PACKAGES =+ "${PN}-mark-good"
 RDEPENDS_${PN} += "${@bb.utils.contains("PREFERRED_PROVIDER_virtual/bootloader", "barebox", "dt-utils-barebox-state", "",d)}"
 RDEPENDS_${PN} += "${@bb.utils.contains("PREFERRED_PROVIDER_virtual/bootloader", "u-boot", "u-boot-fw-utils", "",d)}"
 
-RRECOMMENDS_${PN}_append = " mtd-utils ${PN}-mark-good"
+RRECOMMENDS_${PN}_append = " ${PN}-mark-good"
 
 FILES_${PN}-mark-good = "${systemd_unitdir}/system/rauc-mark-good.service"
 


### PR DESCRIPTION
On targets where we do not have mtd storage, there really is no need to
have mtd-utils installed.
This should be added by the respective BSP layer instead.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>