### PR TITLE
rauc: add rauc-mark-good support for SysVinit

### DIFF
--- a/recipes-core/rauc/files/rauc-mark-good.init
+++ b/recipes-core/rauc/files/rauc-mark-good.init
@@ -1,0 +1,23 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          rauc-mark-good
+# Required-Start:    
+# Required-Stop:     
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Rauc Good-marking Service
+### END INIT INFO
+# Author: <ejo@pengutronix.de>
+
+# Aktionen
+case "$1" in
+    start)
+        rauc status mark-good
+        ;;
+    stop)
+        ;;
+    restart)
+        ;;
+esac
+
+exit 0

--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -5,12 +5,17 @@ SRC_URI_append = " \
   file://system.conf \
   ${RAUC_KEYRING_URI} \
   file://rauc-mark-good.service \
+  file://rauc-mark-good.init \
   "
 
 SYSTEMD_PACKAGES += "${PN}-mark-good"
 SYSTEMD_SERVICE_${PN}-mark-good = "rauc-mark-good.service"
 
-inherit systemd
+INITSCRIPT_PACKAGES = "${PN}-mark-good"
+INITSCRIPT_NAME_${PN}-mark-good = "rauc-mark-good"
+INITSCRIPT_PARAMS_${PN}-mark-good = "start 99 5 2 . stop 20 0 1 6 ."
+
+inherit systemd update-rc.d
 
 do_install () {
 	autotools_do_install
@@ -33,6 +38,9 @@ do_install () {
         install -d ${D}${systemd_unitdir}/system/
         install -m 0644 ${WORKDIR}/rauc-mark-good.service ${D}${systemd_unitdir}/system/
         sed -i -e 's!@BINDIR@!${bindir}!g' ${D}${systemd_unitdir}/system/*.service
+
+        install -d "${D}${sysconfdir}/init.d"
+        install -m 755 "${WORKDIR}/rauc-mark-good.init" "${D}${sysconfdir}/init.d/rauc-mark-good"
 }
 
 PACKAGES =+ "${PN}-mark-good"
@@ -42,6 +50,6 @@ RDEPENDS_${PN} += "${@bb.utils.contains("PREFERRED_PROVIDER_virtual/bootloader",
 
 RRECOMMENDS_${PN}_append = " ${PN}-mark-good"
 
-FILES_${PN}-mark-good = "${systemd_unitdir}/system/rauc-mark-good.service"
+FILES_${PN}-mark-good = "${systemd_unitdir}/system/rauc-mark-good.service ${sysconfdir}/init.d/rauc-mark-good"
 
 PACKAGECONFIG ??= "service network json"


### PR DESCRIPTION
When using RAUC on ancient systems without systemd one will also need to
run the rauc-mark-good service after successful start of the system.

This adds basic support for a simple rauc-mark-good initv service in
package rauc-mark-good.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>