### PR TITLE
do not use {S}ource dir as bundle contents dir

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -90,8 +90,9 @@ python __anonymous() {
             d.appendVarFlag('do_unpack', 'depends', ' ' + image + ':do_deploy')
 }
 
-S = "${WORKDIR}/bundle"
+S = "${WORKDIR}"
 B = "${WORKDIR}/build"
+BUNDLE_DIR = "${S}/bundle"
 
 RAUC_KEY_FILE ??= ""
 RAUC_CERT_FILE ??= ""
@@ -103,7 +104,7 @@ def write_manifest(d):
 
     machine = d.getVar('MACHINE')
     img_fstype = d.getVar('RAUC_IMAGE_FSTYPE')
-    bundle_path = d.expand("${S}")
+    bundle_path = d.expand("${BUNDLE_DIR}")
 
     bb.utils.mkdirhier(bundle_path)
     try:
@@ -192,7 +193,7 @@ do_unpack_append() {
     hooksflags = d.getVarFlags('RAUC_BUNDLE_HOOKS')
     if hooksflags and 'file' in hooksflags:
         hf = hooksflags.get('file')
-        dsthook = d.expand("${S}/%s" % hf)
+        dsthook = d.expand("${BUNDLE_DIR}/%s" % hf)
         shutil.copy(d.expand("${WORKDIR}/%s" % hf), dsthook)
         st = os.stat(dsthook)
         os.chmod(dsthook, st.st_mode | stat.S_IEXEC)
@@ -220,7 +221,7 @@ do_bundle() {
 		--debug \
 		--cert=${RAUC_CERT_FILE} \
 		--key=${RAUC_KEY_FILE} \
-		${S} \
+		${BUNDLE_DIR} \
 		${B}/bundle.raucb
 }
 do_bundle[dirs] = "${B}"


### PR DESCRIPTION
S = ${WORKDIR}/bundle can lead to errors like that:

```
WARNING: dummy-bundle-1.0-r0 do_populate_lic: Could not copy license file .../COPYING: [Errno 2] No such file or directory: '.../dummy-bundle/1.0-r0/bundle/COPYING'
ERROR: dummy-bundle-1.0-r0 do_populate_lic: QA Issue: dummy-bundle: LIC_FILES_CHKSUM points to an invalid file: .../dummy-bundle/1.0-r0/bundle/COPYING [license-checksum]
```

Since bitbake uses S variable as a path to source directory it seems correct to use separate dir for bundle contents.