### PR TITLE
rauc-hawkbit: Add python3-setuptools-scm-native dependencie

### DIFF
--- a/recipes-support/rauc-hawkbit/rauc-hawkbit_git.bb
+++ b/recipes-support/rauc-hawkbit/rauc-hawkbit_git.bb
@@ -3,6 +3,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SUMMARY = "hawkBit client for RAUC"
 
+DEPENDS = "python3-setuptools-scm-native"
+
 SRC_URI = "git://github.com/rauc/rauc-hawkbit.git;protocol=https"
 
 PV = "0.1.0+git${SRCPV}"


### PR DESCRIPTION
Since patch 8fdbb0381dc7d9beee30c38e41e140b0a7c2838b
of Hongxu Jia <hongxu.jia@windriver.com> an explicit dependencie is required.

Signed-off-by: Norbert Wesp <n.wesp@phytec.de>