### PR TITLE
[thud] rauc: add RAUC 1.0 recipe

### DIFF
--- a/recipes-core/rauc/nativesdk-rauc_1.0.bb
+++ b/recipes-core/rauc/nativesdk-rauc_1.0.bb
@@ -1,0 +1,3 @@
+require rauc-1.0.inc
+
+inherit nativesdk

--- a/recipes-core/rauc/rauc-1.0.inc
+++ b/recipes-core/rauc/rauc-1.0.inc
@@ -1,0 +1,6 @@
+require rauc.inc
+
+SRC_URI = "https://github.com/rauc/rauc/releases/download/v${PV}/rauc-${PV}.tar.xz"
+
+SRC_URI[md5sum] = "f800eae12063b0004980581aeb4932c0"
+SRC_URI[sha256sum] = "8875ab0d02b4cb38a211b236855361c18b874b385e6f18dde394ac699f2cf2aa"

--- a/recipes-core/rauc/rauc-git.inc
+++ b/recipes-core/rauc/rauc-git.inc
@@ -6,9 +6,9 @@ SRC_URI = " \
   git://github.com/rauc/rauc.git;protocol=https \
   "
 
-PV = "0.4+git${SRCPV}"
+PV = "1.0+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-SRCREV = "f8b8bd2188d241c5ccdf71ad6b9e1186e56e6a38"
+SRCREV = "059066ebcdb59524d1cd0fdd46862121a08426ef"
 
 DEFAULT_PREFERENCE = "-1"

--- a/recipes-core/rauc/rauc-native_1.0.bb
+++ b/recipes-core/rauc/rauc-native_1.0.bb
@@ -1,0 +1,13 @@
+require rauc-1.0.inc
+
+inherit native deploy
+
+do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
+
+do_deploy() {
+    install -d ${DEPLOY_DIR_TOOLS}
+    install -m 0755 ${B}/rauc ${DEPLOY_DIR_TOOLS}/rauc-${PV}
+    ln -sf rauc-${PV} ${DEPLOY_DIR_TOOLS}/rauc
+}
+
+addtask deploy before do_package after do_install

--- a/recipes-core/rauc/rauc_1.0.bb
+++ b/recipes-core/rauc/rauc_1.0.bb
@@ -1,0 +1,2 @@
+require rauc-1.0.inc
+require rauc-target.inc


### PR DESCRIPTION
This adds RAUC 1.0 to the existing set of recipes.

It is highly recommended to switch to the 1.0 release that is fully
compatible with 0.4 but fixes several potential issues.
However, for those that need to stick to an older version for whatever
reason, the old recipes are kept.

You can set an explicit version as follows somewhere in your global
configuration:

    PREFERRED_VERSION_rauc = "0.4"

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>