### PR TITLE
classes: bundle: support [file] varflag for type 'image'

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -143,7 +143,10 @@ def write_manifest(d):
             img_fstype = slotflags.get('fstype')
 
         if imgtype == 'image':
-            imgsource = "%s-%s.%s" % (d.getVar('RAUC_SLOT_%s' % slot), machine, img_fstype)
+            if slotflags and 'file' in slotflags:
+                imgsource = d.getVarFlag('RAUC_SLOT_%s' % slot, 'file')
+            else:
+                imgsource = "%s-%s.%s" % (d.getVar('RAUC_SLOT_%s' % slot), machine, img_fstype)
             imgname = imgsource
         elif imgtype == 'kernel':
             # TODO: Add image type support


### PR DESCRIPTION
Allow to use a non-autogenerated image name.

Signed-off-by: Gero Schumacher <gero.schumacher@peiker-cee.de>