### PR TITLE
backport to rocko: bundle.bbclass: do not create bundle in content dir

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -73,7 +73,9 @@ python __anonymous() {
             d.appendVarFlag('do_unpack', 'depends', ' ' + image + ':do_deploy')
 }
 
-S = "${WORKDIR}/bundle"
+S = "${WORKDIR}"
+B = "${WORKDIR}/build"
+BUNDLE_DIR = "${S}/bundle"
 
 RAUC_KEY_FILE ??= ""
 RAUC_CERT_FILE ??= ""
@@ -85,7 +87,7 @@ def write_manifest(d):
 
     machine = d.getVar('MACHINE')
     img_fstype = d.getVar('RAUC_IMAGE_FSTYPE')
-    bundle_path = d.expand("${S}")
+    bundle_path = d.expand("${BUNDLE_DIR}")
 
     bb.utils.mkdirhier(bundle_path)
     try:
@@ -168,7 +170,7 @@ do_unpack_append() {
     hooksflags = d.getVarFlags('RAUC_BUNDLE_HOOKS')
     if hooksflags and 'file' in hooksflags:
         hf = hooksflags.get('file')
-        dsthook = d.expand("${S}/%s" % hf)
+        dsthook = d.expand("${BUNDLE_DIR}/%s" % hf)
         shutil.copy(d.expand("${WORKDIR}/%s" % hf), dsthook)
         st = os.stat(dsthook)
         os.chmod(dsthook, st.st_mode | stat.S_IEXEC)
@@ -196,9 +198,11 @@ do_bundle() {
 		--debug \
 		--cert=${RAUC_CERT_FILE} \
 		--key=${RAUC_KEY_FILE} \
-		${S} \
+		${BUNDLE_DIR} \
 		${B}/bundle.raucb
 }
+
+do_bundle[dirs] = "${B}"
 
 addtask bundle after do_configure before do_build
 


### PR DESCRIPTION
backport to rocko:

Currently, RAUC bundles contain an empty bundle.raucb file. Presumably,
mksquashfs creates the output file before starting to walk over the
content dir, and hence it picks up the image it is creating. It doesn't
seem to hurt currently, but it's easy to imagine how things might go
wrong, and it's certainly confusing and unnecessary to have that file
inside the bundle.

The logic in bundle.bbclass is already prepared for using ${S} and ${B}
for distinct purposes, so just make sure that they are indeed distinct.

Signed-off-by: Michael Seidel <github@seidel-michael.de>