### PR TITLE
rauc-mark-good.service: leverage systemd's sync target

### DIFF
--- a/recipes-core/rauc/files/rauc-mark-good.service
+++ b/recipes-core/rauc/files/rauc-mark-good.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Rauc Good-marking Service
+After=boot-complete.target
+Requires=boot-complete.target
 
 [Service]
 ExecStart=@BINDIR@/rauc status mark-good


### PR DESCRIPTION
systemd has a dedicated, special target called `boot-complete.target` that indicates,
that a boot-up is considered successful.

Citing the documentation[0]:
> This target is intended as generic synchronization point for services that shall determine or act on whether the boot process completed successfully. [...]

[0] https://www.freedesktop.org/software/systemd/man/systemd.special.html#boot-complete.target