### PR TITLE
[backport] rauc: add RAUC 1.1 recipe

### DIFF
--- a/recipes-core/rauc/nativesdk-rauc_1.1.bb
+++ b/recipes-core/rauc/nativesdk-rauc_1.1.bb
@@ -1,0 +1,3 @@
+require rauc-1.1.inc
+
+inherit nativesdk

--- a/recipes-core/rauc/rauc-1.1.inc
+++ b/recipes-core/rauc/rauc-1.1.inc
@@ -1,0 +1,6 @@
+require rauc.inc
+
+SRC_URI = "https://github.com/rauc/rauc/releases/download/v${PV}/rauc-${PV}.tar.xz"
+
+SRC_URI[md5sum] = "c81644f96b14304b6bb9f2ac2de9d4fd"
+SRC_URI[sha256sum] = "e49086da3a72564806963d2309e8e2b255492fb314db61f84c9b4cebece98e3f"

--- a/recipes-core/rauc/rauc-git.inc
+++ b/recipes-core/rauc/rauc-git.inc
@@ -6,9 +6,9 @@ SRC_URI = " \
   git://github.com/rauc/rauc.git;protocol=https \
   "
 
-PV = "1.0+git${SRCPV}"
+PV = "1.1+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-SRCREV = "059066ebcdb59524d1cd0fdd46862121a08426ef"
+SRCREV = "a1142006f01291b29bd5159edead178cb3be8ae8"
 
 DEFAULT_PREFERENCE = "-1"

--- a/recipes-core/rauc/rauc-native_1.1.bb
+++ b/recipes-core/rauc/rauc-native_1.1.bb
@@ -1,0 +1,13 @@
+require rauc-1.1.inc
+
+inherit native deploy
+
+do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
+
+do_deploy() {
+    install -d ${DEPLOY_DIR_TOOLS}
+    install -m 0755 ${B}/rauc ${DEPLOY_DIR_TOOLS}/rauc-${PV}
+    ln -sf rauc-${PV} ${DEPLOY_DIR_TOOLS}/rauc
+}
+
+addtask deploy before do_package after do_install

--- a/recipes-core/rauc/rauc_1.1.bb
+++ b/recipes-core/rauc/rauc_1.1.bb
@@ -1,0 +1,2 @@
+require rauc-1.1.inc
+require rauc-target.inc


### PR DESCRIPTION
This adds RAUC 1.1 to the existing set of recipes.

It is highly recommended to switch to the 1.1 release that is fully
compatible with 1.0 but fixes several potential issues.
However, for those that need to stick to an older version for whatever
reason, the old recipes are kept.

You can set an explicit version as follows somewhere in your global
configuration:

  PREFERRED_VERSION_rauc = "1.0"

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>