### PR TITLE
Add CI testing via circleci

### DIFF
--- a/.circleci/bblayers.conf.sample
+++ b/.circleci/bblayers.conf.sample
@@ -1,0 +1,12 @@
+POKY_BBLAYERS_CONF_VERSION = "2"
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+BBLAYERS ?= " \
+  ##OEROOT##/meta \
+  ##OEROOT##/meta-poky \
+  ##OEROOT##/meta-yocto-bsp \
+  ##OEROOT##/../meta-rauc \
+  ##OEROOT##/../meta-oe/meta-oe \
+  ##OEROOT##/../meta-oe/meta-python \
+  ##OEROOT##/../meta-oe/meta-filesystems \
+  "

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: crops/yocto:ubuntu-18.10-builder
+        environment:
+          LC_ALL: en_US.UTF-8
+          LANG: en_US.UTF-8
+          LANGUAGE: en_US.UTF-8
+    steps:
+      - checkout
+      - run:
+          name: Clone poky
+          command: git clone git://git.yoctoproject.org/poky
+      - run:
+          name: Clone meta-oe
+          command: git clone https://github.com/openembedded/meta-openembedded.git meta-oe
+      - run:
+          name: Link meta-rauc
+          command: ln -sf . meta-rauc
+      - run:
+          name: Create meta-this
+          command: mkdir -p meta-this/conf/ && cp .circleci/*.sample meta-this/conf/.
+      - run:
+          name: Initialize build directory
+          command: TEMPLATECONF=../meta-this/conf source poky/oe-init-build-env build
+      - run:
+          name: Run bitbake
+          command: source poky/oe-init-build-env build && bitbake rauc
+
+
+workflows:
+  workflow:
+    jobs:
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,12 @@ jobs:
           LANGUAGE: en_US.UTF-8
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - sstate-test-{{ .Branch }}-{{ .Revision }}
+            - sstate-test-{{ .Branch }}-
+            - sstate-test-master-
+            - sstate-test-
       - run:
           name: Clone poky
           command: git clone git://git.yoctoproject.org/poky
@@ -28,6 +34,10 @@ jobs:
       - run:
           name: Run bitbake
           command: source poky/oe-init-build-env build && bitbake rauc
+      - save_cache:
+          key: sstate-test-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - "build/sstate-cache/"
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,14 @@ jobs:
           name: Initialize build directory
           command: TEMPLATECONF=../meta-this/conf source poky/oe-init-build-env build
       - run:
-          name: Run bitbake
+          name: Build rauc
           command: source poky/oe-init-build-env build && bitbake rauc
+      - run:
+          name: Build rauc-native
+          command: source poky/oe-init-build-env build && bitbake rauc-native
+      - run:
+          name: Build rauc-hawkbit
+          command: source poky/oe-init-build-env build && bitbake rauc-hawkbit
       - save_cache:
           key: sstate-test-{{ .Branch }}-{{ .Revision }}
           paths:

--- a/.circleci/local.conf.sample
+++ b/.circleci/local.conf.sample
@@ -1,0 +1,24 @@
+MACHINE ??= "qemux86-64"
+DISTRO ?= "poky"
+PACKAGE_CLASSES ?= "package_rpm"
+EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
+USER_CLASSES ?= "buildstats image-mklibs image-prelink"
+PATCHRESOLVE = "noop"
+BB_DISKMON_DIRS ??= "\
+    STOPTASKS,${TMPDIR},1G,100K \
+    STOPTASKS,${DL_DIR},1G,100K \
+    STOPTASKS,${SSTATE_DIR},1G,100K \
+    STOPTASKS,/tmp,100M,100K \
+    ABORT,${TMPDIR},100M,1K \
+    ABORT,${DL_DIR},100M,1K \
+    ABORT,${SSTATE_DIR},100M,1K \
+    ABORT,/tmp,10M,1K"
+PACKAGECONFIG_append_pn-qemu-system-native = " sdl"
+PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
+CONF_VERSION = "1"
+
+SSTATE_MIRRORS = "\
+file://.* http://sstate.yoctoproject.org/dev/PATH;downloadfilename=PATH \n \
+file://.* http://sstate.yoctoproject.org/2.6/PATH;downloadfilename=PATH \n \
+file://.* http://sstate.yoctoproject.org/2.7/PATH;downloadfilename=PATH \n \
+"

--- a/.circleci/local.conf.sample
+++ b/.circleci/local.conf.sample
@@ -17,6 +17,7 @@ PACKAGECONFIG_append_pn-qemu-system-native = " sdl"
 PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
 CONF_VERSION = "1"
 
+SSTATE_DIR ?= "${TOPDIR}/sstate-cache"
 SSTATE_MIRRORS = "\
 file://.* http://sstate.yoctoproject.org/dev/PATH;downloadfilename=PATH \n \
 file://.* http://sstate.yoctoproject.org/2.6/PATH;downloadfilename=PATH \n \


### PR DESCRIPTION
circleci allows us to cache results which enables saving and restoring sstate-cache to speed up builds.

This, combined with using sstate.yoctoproject.org reduces the build time of meta-rauc components to a few minutes and makes it appropriate for CI testing.