### PR TITLE
classes: bundle: do not generate default packages and deps

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -42,6 +42,9 @@ LICENSE = "MIT"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
+PACKAGES = ""
+INHIBIT_DEFAULT_DEPS = "1"
+
 RAUC_IMAGE_FSTYPE ??= "${@(d.getVar('IMAGE_FSTYPES') or "").split()[0]}"
 
 do_fetch[cleandirs] = "${S}"


### PR DESCRIPTION
We create a bundle and thus do not require generating any of the default
packages. Thus set

  PACKAGES = ""

We also do not require default dependencies such as C compiler for a
bundle, thus also set

  INHIBIT_DEFAULT_DEPS = "1"

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>