### PR TITLE
python3-gbulb: Update to 0.6.1 for Python 3.7 support.

### DIFF
--- a/recipes-devtools/python-gbulb/python3-gbulb_0.6.1.bb
+++ b/recipes-devtools/python-gbulb/python3-gbulb_0.6.1.bb
@@ -1,10 +1,10 @@
 SUMMARY = "GLib event loop for tulip (PEP 3156)"
 HOMEPAGE = "http://github.com/nathan-hoad/gbulb"
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://PKG-INFO;md5=ceb5c94bee9ee3df2a39952beeb0bc83"
+LIC_FILES_CHKSUM = "file://PKG-INFO;md5=c19ea442ddc4f12594f5e77bb9d3dcd4"
 
-SRC_URI[md5sum] = "424fea3695a8ff6bd39a8cbadbde008b"
-SRC_URI[sha256sum] = "00e92fda2ed4ee8c1a48b423f4f7a387dbc288d4bc36f5a8d0c8ac2759c47ea5"
+SRC_URI[md5sum] = "b1b51b8548f34eb5649ebd98faf24955"
+SRC_URI[sha256sum] = "119bcf9961a976a8240fee667722b41a23603119b7a0037d03f95650de062fc2"
 
 PYPI_PACKAGE = "gbulb"
 


### PR DESCRIPTION
@ejoerns: Here we go.

rauc-demo now fails for another, but unrelated reason on warrior.