### PR TITLE
.circleci: config.yml: replace removed crops/yocto image 18.10 by 19.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: crops/yocto:ubuntu-18.10-builder
+      - image: crops/yocto:ubuntu-19.04-builder
         environment:
           LC_ALL: en_US.UTF-8
           LANG: en_US.UTF-8


### PR DESCRIPTION
Docker hub crops/yocto removed ubuntu-18.10-builder tag which causes
circleci workflow to fail with:

| Error response from daemon: manifest for crops/yocto:ubuntu-18.10-builder not found

Replace this by the more recent and available tag ubuntu-19.04-builder.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>