### PR TITLE
rauc: rauc-target.inc: improve RDPENDS handling

### DIFF
--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -45,8 +45,8 @@ do_install () {
 
 PACKAGES =+ "${PN}-mark-good"
 
-RDEPENDS_${PN} += "${@bb.utils.contains("PREFERRED_PROVIDER_virtual/bootloader", "barebox", "dt-utils-barebox-state", "",d)}"
-RDEPENDS_${PN} += "${@bb.utils.contains("PREFERRED_PROVIDER_virtual/bootloader", "u-boot", "u-boot-fw-utils", "",d)}"
+RDEPENDS_${PN} += "${@"dt-utils-barebox-state" if "barebox" in d.getVar("PREFERRED_PROVIDER_virtual/bootloader") else ""}"
+RDEPENDS_${PN} += "${@"u-boot-fw-utils" if "u-boot" in d.getVar("PREFERRED_PROVIDER_virtual/bootloader") else ""}"
 
 RRECOMMENDS_${PN}_append = " ${PN}-mark-good"
 


### PR DESCRIPTION
The bb.utils.contains() mechanism won't work if the bootloader isn't
named exactly barebox or u-boot. A quick google serch shows that there
are a few u-boot variants: u-boot-imx, u-boot-fslc, u-boot-seco,
u-boot-digilent, ... We should take this into account and make a
substring search.

Signed-off-by: Marco Felsch <m.felsch@pengutronix.de>