### PR TITLE
rauc: rauc-target.inc: fix do_install dependency

### DIFF
--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -43,6 +43,8 @@ do_install () {
         install -m 755 "${WORKDIR}/rauc-mark-good.init" "${D}${sysconfdir}/init.d/rauc-mark-good"
 }
 
+do_install[vardeps] = "RAUC_KEYRING_FILE"
+
 PACKAGES =+ "${PN}-mark-good"
 
 RDEPENDS_${PN} += "${@bb.utils.contains("PREFERRED_PROVIDER_virtual/bootloader", "barebox", "dt-utils-barebox-state", "",d)}"


### PR DESCRIPTION
Without the fix bitbake didn't notice that the RAUC_KEYRING_FILE was
changed automatically.

Signed-off-by: Marco Felsch <m.felsch@pengutronix.de>