### PR TITLE
rauc: update to v1.2

### DIFF
--- a/recipes-core/rauc/nativesdk-rauc_1.1.bb
+++ b/recipes-core/rauc/nativesdk-rauc_1.1.bb
@@ -1,3 +1,0 @@
-require rauc-1.1.inc
-
-inherit nativesdk

--- a/recipes-core/rauc/nativesdk-rauc_1.2.bb
+++ b/recipes-core/rauc/nativesdk-rauc_1.2.bb
@@ -1,0 +1,3 @@
+require rauc-1.2.inc
+
+inherit nativesdk

--- a/recipes-core/rauc/rauc-1.1.inc
+++ b/recipes-core/rauc/rauc-1.1.inc
@@ -1,6 +1,0 @@
-require rauc.inc
-
-SRC_URI = "https://github.com/rauc/rauc/releases/download/v${PV}/rauc-${PV}.tar.xz"
-
-SRC_URI[md5sum] = "c81644f96b14304b6bb9f2ac2de9d4fd"
-SRC_URI[sha256sum] = "e49086da3a72564806963d2309e8e2b255492fb314db61f84c9b4cebece98e3f"

--- a/recipes-core/rauc/rauc-1.2.inc
+++ b/recipes-core/rauc/rauc-1.2.inc
@@ -1,0 +1,6 @@
+require rauc.inc
+
+SRC_URI = "https://github.com/rauc/rauc/releases/download/v${PV}/rauc-${PV}.tar.xz"
+
+SRC_URI[md5sum] = "e2a1772825c6ea900e4824b670846a00"
+SRC_URI[sha256sum] = "224683fc1fac50ccb89128aa786445cd8e26bb25deafd4410e0807187376e661"

--- a/recipes-core/rauc/rauc-native_1.2.bb
+++ b/recipes-core/rauc/rauc-native_1.2.bb
@@ -1,4 +1,4 @@
-require rauc-1.1.inc
+require rauc-1.2.inc
 
 inherit native deploy
 

--- a/recipes-core/rauc/rauc.inc
+++ b/recipes-core/rauc/rauc.inc
@@ -14,7 +14,7 @@ EXTRA_OECONF += "\
 
 RRECOMMENDS_${PN} = "squashfs-tools"
 
-PACKAGECONFIG[service] = "--enable-service,--enable-service=no,,${PN}-service"
+PACKAGECONFIG[service] = "--enable-service,--enable-service=no,dbus,${PN}-service"
 PACKAGECONFIG[network] = "--enable-network,--enable-network=no,curl"
 PACKAGECONFIG[json]    = "--enable-json,--enable-json=no,json-glib"
 

--- a/recipes-core/rauc/rauc_1.2.bb
+++ b/recipes-core/rauc/rauc_1.2.bb
@@ -1,2 +1,2 @@
-require rauc-1.1.inc
+require rauc-1.2.inc
 require rauc-target.inc


### PR DESCRIPTION
RAUC 1.2 requires dbus pkg-config files in case of service being
enabled.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>