### PR TITLE
rauc: more generic and stable boot tool guessing

### DIFF
--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -45,8 +45,24 @@ do_install () {
 
 PACKAGES =+ "${PN}-mark-good"
 
-RDEPENDS_${PN} += "${@"dt-utils-barebox-state" if "barebox" in d.getVar("PREFERRED_PROVIDER_virtual/bootloader") else ""}"
-RDEPENDS_${PN} += "${@"u-boot-fw-utils" if "u-boot" in d.getVar("PREFERRED_PROVIDER_virtual/bootloader") else ""}"
+# some magic to get the tool to interact with bootloader storage
+python __anonymous () {
+    bootloader = d.getVar("PREFERRED_PROVIDER_virtual/bootloader")
+
+    if not bootloader:
+        return
+
+    if "barebox" in bootloader:
+        boothelper = " dt-utils-barebox-state"
+    elif "u-boot" in bootloader:
+        boothelper = " u-boot-fw-utils"
+    elif "grub" in bootloader:
+        boothelper = " grub-editenv"
+    else:
+        return
+
+    d.appendVar("RDEPENDS_%s" % d.getVar('PN'), boothelper)
+}
 
 RRECOMMENDS_${PN}_append = " ${PN}-mark-good"
 


### PR DESCRIPTION
Implementing guessing of the valid boot tools in inline python
oneliners turned out to be both error-prone and hard to read.

This fixes the current handling which fails if
PREFERRED_PROVIDER_virtual/bootloader is not set and additionally
extends it by also covering 'grub' as possible bootloader.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>