### PR TITLE
rauc-target: disable the watching of a block device node with inotify

### DIFF
--- a/recipes-core/rauc/files/61-block-nowatch.rules
+++ b/recipes-core/rauc/files/61-block-nowatch.rules
@@ -1,0 +1,5 @@
+# Don't watch metadata changes, caused by tools closing the device node which was opened for writing.
+# Barebox-state, mbr-switch and eMMC-bootloader update operates on the root device node. This triggers
+# the inotify which causes a partition rescan. This is racy as devices might disappear while RAUC
+# tries to access them during a update.
+ACTION!="remove", SUBSYSTEM=="block", OPTIONS="nowatch"

--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -6,6 +6,7 @@ SRC_URI_append = " \
   ${RAUC_KEYRING_URI} \
   file://rauc-mark-good.service \
   file://rauc-mark-good.init \
+  file://61-block-nowatch.rules \
   "
 
 SYSTEMD_PACKAGES += "${PN}-mark-good"
@@ -41,6 +42,9 @@ do_install () {
 
         install -d "${D}${sysconfdir}/init.d"
         install -m 755 "${WORKDIR}/rauc-mark-good.init" "${D}${sysconfdir}/init.d/rauc-mark-good"
+
+        install -d ${D}${nonarch_base_libdir}/udev/rules.d
+        install -m 0644 ${WORKDIR}/61-block-nowatch.rules ${D}${nonarch_base_libdir}/udev/rules.d/
 }
 
 PACKAGES =+ "${PN}-mark-good"


### PR DESCRIPTION
Barebox-state, mbr-switch and eMMC-bootloader updates operates on the
root device node. This triggers the inotify which causes a partition
rescan. This is racy as devices might disappear while RAUC tries to
access them during a update.

Signed-off-by: Marco Felsch <m.felsch@pengutronix.de>