### PR TITLE
classes: bundle: quote cert and key argument values for bundle creation

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -225,8 +225,8 @@ do_bundle() {
 	fi
 	${STAGING_DIR_NATIVE}${bindir}/rauc bundle \
 		--debug \
-		--cert=${RAUC_CERT_FILE} \
-		--key=${RAUC_KEY_FILE} \
+		--cert="${RAUC_CERT_FILE}" \
+		--key="${RAUC_KEY_FILE}" \
 		${BUNDLE_DIR} \
 		${B}/bundle.raucb
 }


### PR DESCRIPTION
These variables can contain PKCS#11 URIs, for which `;` and `&` are
valid characters. Avoid parsing issues by quoting them.