### PR TITLE
rauc-hawkbit: Add systemd service

### DIFF
--- a/recipes-support/rauc-hawkbit/files/rauc-hawkbit.service
+++ b/recipes-support/rauc-hawkbit/files/rauc-hawkbit.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=rauc-hawkbit client service
+Requires=rauc.service
+
+[Service]
+ExecStart=@BINDIR@/rauc-hawkbit-client -c @SYSCONFDIR@/rauc-hawkbit/config.cfg
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-support/rauc-hawkbit/rauc-hawkbit_git.bb
+++ b/recipes-support/rauc-hawkbit/rauc-hawkbit_git.bb
@@ -5,13 +5,34 @@ SUMMARY = "hawkBit client for RAUC"
 
 DEPENDS = "python3-setuptools-scm-native"
 
-SRC_URI = "git://github.com/rauc/rauc-hawkbit.git;protocol=https"
+SRC_URI = " \
+    git://github.com/rauc/rauc-hawkbit.git;protocol=https \
+    file://rauc-hawkbit.service \
+"
 
 PV = "0.1.0-9+git${SRCPV}"
 SRCREV = "6a1e79b0b7c83da866e0602201db49d6e74d7dd2"
 
 S = "${WORKDIR}/git"
 
-inherit setuptools3
+inherit setuptools3 systemd
+
+PACKAGES =+ "${PN}-service"
+SYSTEMD_SERVICE_${PN}-service = "rauc-hawkbit.service"
+SYSTEMD_PACKAGES = "${PN}-service"
+
+do_install_append() {
+	install -d ${D}${sysconfdir}/${BPN}/
+	install -m 0644 ${S}/rauc_hawkbit/config.cfg ${D}${sysconfdir}/${BPN}/config.cfg
+	install -d ${D}${systemd_unitdir}/system/
+	install -m 0644 ${WORKDIR}/rauc-hawkbit.service ${D}${systemd_unitdir}/system/
+	sed -i -e 's!@BINDIR@!${bindir}!g' -e 's!@SYSCONFDIR@!${sysconfdir}!g' \
+		${D}${systemd_unitdir}/system/rauc-hawkbit.service
+}
 
 RDEPENDS_${PN} += "python3-aiohttp python3-gbulb"
+FILES_${PN}-service = " \
+    ${bindir}/rauc-hawkbit-client \
+    ${sysconfdir}/${BPN}/config.cfg \
+    ${systemd_unitdir}/system/rauc-hawkbit.service \
+"


### PR DESCRIPTION
This adds a systemd service for the rauc-hawkbit client to easily start and stop it. ~By default, this service is disabled, as I think not everyone wants to use the rauc-hawkbit client on their system.~

Additionally, for an easier configuration of the client the config file is being linked to /etc.

These changes should be applied to sumo and later.