### PR TITLE
bundle.bbclass: check that a hook file is provided

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -154,12 +154,16 @@ def write_manifest(d):
     manifest.write('\n')
 
     hooksflags = d.getVarFlags('RAUC_BUNDLE_HOOKS')
-    if hooksflags and 'file' in hooksflags:
+    have_hookfile = False
+    if 'file' in hooksflags:
+        have_hookfile = True
         manifest.write('[hooks]\n')
         manifest.write("filename=%s\n" % hooksflags.get('file'))
         if 'hooks' in hooksflags:
             manifest.write("hooks=%s\n" % hooksflags.get('hooks'))
         manifest.write('\n')
+    elif 'hooks' in hooksflags:
+        bb.warn("Suspicious use of RAUC_BUNDLE_HOOKS[hooks] without RAUC_BUNDLE_HOOKS[file]")
 
     for slot in (d.getVar('RAUC_BUNDLE_SLOTS') or "").split():
         slotflags = d.getVarFlags('RAUC_SLOT_%s' % slot)
@@ -206,6 +210,8 @@ def write_manifest(d):
 
         manifest.write("filename=%s\n" % imgname)
         if slotflags and 'hooks' in slotflags:
+            if not have_hookfile:
+                bb.warn("A hook is defined for slot %s, but RAUC_BUNDLE_HOOKS[file] is not defined" % slot)
             manifest.write("hooks=%s\n" % slotflags.get('hooks'))
         manifest.write("\n")
 


### PR DESCRIPTION
It doesn't make much sense to define global or per-slot hooks without
providing a file that actually implements those, so at least warn
about that - maybe bb.warn can be promoted to an error later.

It might make sense to move this sanity check to the "rauc bundle"
command, so one would also catch the cases where the bundles are not
created via Yocto. Also, a run-time warning when (or before)
installing such a malformed bundle would be nice. But that's all a lot
more code change than this.

Signed-off-by: Rasmus Villemoes <rasmus.villemoes@prevas.dk>