### PR TITLE
bundle.bbclass: write manifest during do_configure, not do_unpack

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -62,7 +62,6 @@ RAUC_IMAGE_FSTYPE[doc] = "Specifies the default file name extension to expect fo
 
 do_fetch[cleandirs] = "${S}"
 do_patch[noexec] = "1"
-do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 do_install[noexec] = "1"
 do_populate_sysroot[noexec] = "1"
@@ -220,7 +219,7 @@ def write_manifest(d):
 
     manifest.close()
 
-do_unpack_append() {
+python do_configure() {
     import shutil
     import os
     import stat


### PR DESCRIPTION
I have a hook script in which I want to substitute some paths that, to
ensure consistency, are defined in Bitbake variables. So I use the
pattern

SRC_URI += "file://hook.sh"
fixup_hook_script() {
    sed -i -e 's|__SYSDATA_MNTPOINT__|${SYSDATA_MNTPOINT}|' \
        ${WORKDIR}/hook.sh
}
do_unpack[postfuncs] += "fixup_hook_script"

However, that doesn't work for RAUC bundles, since there's no place
for me to hook in before write_manifest(), called from the do_unpack
task function, has snatched a copy of the hook.sh that was put in
${WORKDIR} earlier in do_unpack.

Of course, one could adapt the above to patch the copy in the bundle
directory instead, but the above is a bit of a simplification: To
reduce the sed boilerplate, I'm eventually going to switch to a helper
class that automatically does the Bitbake substitution (on the set of
files I provide in a list), and that just fixes up the copies in
${WORKDIR} at do_unpack postfunc time.

So to allow the above rather standard idiom, and other fixups people
might reasonably expect to be able to do around do_unpack/do_patch
time, write the manifest as part of do_configure. That also makes
semantic sense, IMHO, and do_bundle is already defined to happen after
do_configure.

I think the risk that someone has explicitly unset
do_configure[noexec] in order to provide their own do_configure is
rather small.

Signed-off-by: Rasmus Villemoes <rasmus.villemoes@prevas.dk>