### PR TITLE
classes: bundle: support overriding file names in the bundle

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -33,6 +33,10 @@
 #   RAUC_SLOT_dtb[type] ?= "file"
 #   RAUC_SLOT_dtb[file] ?= "${MACHINE}-variant1.dtb"
 #
+# To override the file name used in the bundle use 'rename'
+#   RAUC_SLOT_rootfs ?= "core-image-minimal"
+#   RAUC_SLOT_rootfs[rename] ?= "rootfs.ext4"
+#
 # To add additional artifacts to the bundle you can use RAUC_BUNDLE_EXTRA_FILES
 # and RAUC_BUNDLE_EXTRA_DEPENDS.
 # For files from the WORKDIR (fetched using SRC_URI) you can write:
@@ -203,6 +207,9 @@ def write_manifest(d):
             imgname = "%s.%s" % (imgsource, "img")
         else:
             raise bb.build.FuncFailed('Unknown image type: %s' % imgtype)
+
+        if slotflags and 'rename' in slotflags:
+            imgname = slotflags.get('rename')
 
         manifest.write("filename=%s\n" % imgname)
         if slotflags and 'hooks' in slotflags:


### PR DESCRIPTION
This can be useful if the name produced by the build system doesn't have the suffix expected by rauc or if there is information in the name that should not be published.