### PR TITLE
rauc-hawkbit_git.bb add missing runtime dependency

### DIFF
--- a/recipes-support/rauc-hawkbit/rauc-hawkbit_git.bb
+++ b/recipes-support/rauc-hawkbit/rauc-hawkbit_git.bb
@@ -14,4 +14,4 @@ S = "${WORKDIR}/git"
 
 inherit setuptools3
 
-RDEPENDS_${PN} += "python3-aiohttp python3-gbulb"
+RDEPENDS_${PN} += "python3-aiohttp python3-gbulb python3-netserver"


### PR DESCRIPTION
Adds missing python3-netserver dependency. Without i got the following error:

```
Traceback (most recent call last):
  File "/usr/bin/rauc-hawkbit-client", line 5, in <module>
    import aiohttp
  File "/usr/lib/python3.7/site-packages/aiohttp/__init__.py", line 6, in <module>
    from .client import (
  File "/usr/lib/python3.7/site-packages/aiohttp/client.py", line 32, in <module>
    from . import hdrs, http, payload
  File "/usr/lib/python3.7/site-packages/aiohttp/http.py", line 1, in <module>
    import http.server
  File "/usr/lib/python3.7/http/server.py", line 102, in <module>
    import socketserver
ModuleNotFoundError: No module named 'socketserver'
```