### PR TITLE
Add recipe for rauc-hawkbit-updater

### DIFF
--- a/recipes-support/rauc-hawkbit-updater/rauc-hawkbit-updater_git.bb
+++ b/recipes-support/rauc-hawkbit-updater/rauc-hawkbit-updater_git.bb
@@ -1,0 +1,26 @@
+SUMMARY = "The RAUC hawkBit updater operates as an interface between the RAUC D-Bus API and the hawkBit DDI API."
+HOMEPAGE = "https://github.com/rauc/rauc-hawkbit-updater"
+
+LICENSE = "LGPLv2.1"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1a6d268fd218675ffea8be556788b780"
+
+SRC_URI = "git://github.com/rauc/rauc-hawkbit-updater.git;protocol=https"
+SRCREV = "d909982e9e4b84cb76b98bf85f25a0a88472301a"
+S = "${WORKDIR}/git"
+PV = "0.0+git${SRCPV}"
+
+inherit cmake pkgconfig systemd
+
+SYSTEMD_SERVICE_${PN} = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'rauc-hawkbit-updater.service', '', d)}"
+
+PACKAGECONFIG ??= " \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)} \
+"
+PACKAGECONFIG[systemd] = "-DWITH_SYSTEMD=ON,,systemd"
+
+DEPENDS = "curl glib-2.0-native json-glib"
+
+do_install_append () {
+	install -d ${D}${sysconfdir}/${PN}
+	install -m 644 ${S}/config.conf.example ${D}${sysconfdir}/${PN}/config.conf
+}


### PR DESCRIPTION
rauc-hawkbit-updater is a simple command line tool (or daemon) written
in C (glib). It is a port of the RAUC hawkBit client written in Python.
The daemon operates as an interface between the RAUC D-Bus API and the
hawkBit DDI API.

Please apply to sumo and later.