### PR TITLE
rauc: fix upstream version check

### DIFF
--- a/recipes-core/rauc/rauc-1.2.inc
+++ b/recipes-core/rauc/rauc-1.2.inc
@@ -4,3 +4,5 @@ SRC_URI = "https://github.com/rauc/rauc/releases/download/v${PV}/rauc-${PV}.tar.
 
 SRC_URI[md5sum] = "e2a1772825c6ea900e4824b670846a00"
 SRC_URI[sha256sum] = "224683fc1fac50ccb89128aa786445cd8e26bb25deafd4410e0807187376e661"
+
+UPSTREAM_CHECK_URI = "https://github.com/${BPN}/${BPN}/releases"


### PR DESCRIPTION
Fixes:

```
$ ./auto-upgrade-helper/upgradehelper.py rauc
INFO: Skip package rauc (status = UNKNOWN_BROKEN, current version = 1.2, next version = N/A)
```

With this commit:

```
INFO: Skip package rauc (status = MATCH, current version = 1.2, next version = 1.2)
```

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>