### PR TITLE
rauc-mark-good: Set service to oneshot

### DIFF
--- a/recipes-core/rauc/files/rauc-mark-good.service
+++ b/recipes-core/rauc/files/rauc-mark-good.service
@@ -2,6 +2,7 @@
 Description=Rauc Good-marking Service
 
 [Service]
+Type=oneshot
 ExecStart=@BINDIR@/rauc status mark-good
 
 [Install]


### PR DESCRIPTION
Setting rauc-mark-good to oneshot was also discussed in issue #86

I faced a different problem with the same solution:
Because the rauc-mark-good.service has Type=simple the boot process
continues after the service was started NOT after rauc mark good was finished.
It is not possible to start a service that depends on rauc-mark-good.service because the execution of the service lasts about 1,5s in our case (write to EEPROM).

With this patch it is possible to order a service just after `rauc-mark-good` is finished.