### PR TITLE
conf: layer.conf: python3-yarl bbappend requires meta-python

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,10 +9,7 @@ BBFILE_COLLECTIONS += "rauc"
 BBFILE_PATTERN_rauc = "^${LAYERDIR}/"
 BBFILE_PRIORITY_rauc = "6"
 
-LAYERDEPENDS_rauc = "core"
-
-# meta-python is needed to build/run hawkbit-client
-LAYERRECOMMENDS_rauc = "meta-python"
+LAYERDEPENDS_rauc = "core meta-python"
 
 # meta-filesystems is needed to build cascync with fuse support (the default)
 LAYERRECOMMENDS_rauc += "meta-filesystems"


### PR DESCRIPTION
Since ce1fe455f8cc83484eea4b4b515a3104d1aac02a ("python3: remove outdated packages") meta-rauc has a .bbappend file for the recipe python3-yarl (version 1.3.0).
This now moves meta-python from a recommendation to an actual dependency as otherwise building the layer will fail with:

```
ERROR: No recipes available for:
 /path/to/bsp/meta-rauc/recipes-devtools/python/python3-yarl_1.3.0.bbappend
```

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>