### PR TITLE
rauc: fix RRECOMMENDS for rauc-native -> squashfs-tools-native

### DIFF
--- a/recipes-core/rauc/rauc-native.inc
+++ b/recipes-core/rauc/rauc-native.inc
@@ -1,6 +1,7 @@
 inherit native deploy
 
 DEPENDS = "openssl-native glib-2.0-native"
+RRECOMMENDS_${PN} = "squashfs-tools-native"
 
 do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
 

--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -1,6 +1,8 @@
 RAUC_KEYRING_FILE ??= "ca.cert.pem"
 RAUC_KEYRING_URI ??= "file://${RAUC_KEYRING_FILE}"
 
+RRECOMMENDS_${PN} = "squashfs-tools"
+
 SRC_URI_append = " \
   file://system.conf \
   ${RAUC_KEYRING_URI} \

--- a/recipes-core/rauc/rauc.inc
+++ b/recipes-core/rauc/rauc.inc
@@ -12,8 +12,6 @@ EXTRA_OECONF += "\
         --with-dbussystemservicedir=${datadir}/dbus-1/system-services \
         "
 
-RRECOMMENDS_${PN} = "squashfs-tools"
-
 PACKAGECONFIG[nocreate]  = "--disable-create,--enable-create,"
 PACKAGECONFIG[service] = "--enable-service,--enable-service=no,dbus,${PN}-service"
 PACKAGECONFIG[network] = "--enable-network,--enable-network=no,curl"


### PR DESCRIPTION
Currently rauc-native RRECOMMENDS squashfs-tools, but it should really
be squashfs-tools-native instead. Normally this distinction is handled
by some magic in native.bbclass, which munges all package relationships
to hack -native onto the end of the names:

https://github.com/openembedded/openembedded-core/blob/master/meta/classes/native.bbclass#L141

but that code only runs if you use BBCLASSEXTEND = "native". If the
recipe explicitly inherits native, as rauc-native does, the renaming
does not happen. Thus the recipe needs to spell out its -native
dependency explicitly.