### PR TITLE
Fix broken master build caused by removed DEPLOY_DIR_TOOLS

### DIFF
--- a/recipes-core/rauc/rauc-native_1.3.bb
+++ b/recipes-core/rauc/rauc-native_1.3.bb
@@ -5,9 +5,9 @@ inherit native deploy
 do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
 
 do_deploy() {
-    install -d ${DEPLOY_DIR_TOOLS}
-    install -m 0755 ${B}/rauc ${DEPLOY_DIR_TOOLS}/rauc-${PV}
-    ln -sf rauc-${PV} ${DEPLOY_DIR_TOOLS}/rauc
+    install -d ${DEPLOYDIR}
+    install -m 0755 ${B}/rauc ${DEPLOYDIR}/rauc-${PV}
+    ln -sf rauc-${PV} ${DEPLOYDIR}/rauc
 }
 
 addtask deploy before do_package after do_install

--- a/recipes-core/rauc/rauc-native_1.3.bb
+++ b/recipes-core/rauc/rauc-native_1.3.bb
@@ -2,8 +2,6 @@ require rauc-1.3.inc
 
 inherit native deploy
 
-do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
-
 do_deploy() {
     install -d ${DEPLOYDIR}
     install -m 0755 ${B}/rauc ${DEPLOYDIR}/rauc-${PV}

--- a/recipes-core/rauc/rauc-native_git.bb
+++ b/recipes-core/rauc/rauc-native_git.bb
@@ -2,8 +2,6 @@ require rauc-git.inc
 
 inherit native deploy
 
-do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
-
 do_deploy() {
     install -d ${DEPLOYDIR}
     install -m 0755 ${B}/rauc ${DEPLOYDIR}/rauc-${PV}

--- a/recipes-core/rauc/rauc-native_git.bb
+++ b/recipes-core/rauc/rauc-native_git.bb
@@ -5,9 +5,9 @@ inherit native deploy
 do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
 
 do_deploy() {
-    install -d ${DEPLOY_DIR_TOOLS}
-    install -m 0755 ${B}/rauc ${DEPLOY_DIR_TOOLS}/rauc-${PV}
-    ln -sf rauc-${PV} ${DEPLOY_DIR_TOOLS}/rauc
+    install -d ${DEPLOYDIR}
+    install -m 0755 ${B}/rauc ${DEPLOYDIR}/rauc-${PV}
+    ln -sf rauc-${PV} ${DEPLOYDIR}/rauc
 }
 
 addtask deploy before do_package after do_install


### PR DESCRIPTION
This fixes building meta-rauc master against poky master.

They decided to remove variable `DEPLOY_DIR_TOOLS` and apparently we need to follow this decision to fix broken rauc-native build.

Reference Mail: https://lists.openembedded.org/g/openembedded-core/message/139342

Note this will change rauc host tool installation from tmp/deploy/tools to tmp/deploy/images.