### PR TITLE
rauc-hawkbit-updater: Add user rauc-hawkbit

### DIFF
--- a/recipes-support/rauc-hawkbit-updater/rauc-hawkbit-updater_git.bb
+++ b/recipes-support/rauc-hawkbit-updater/rauc-hawkbit-updater_git.bb
@@ -9,7 +9,7 @@ SRCREV = "d909982e9e4b84cb76b98bf85f25a0a88472301a"
 S = "${WORKDIR}/git"
 PV = "0.0+git${SRCPV}"
 
-inherit cmake pkgconfig systemd
+inherit cmake pkgconfig systemd useradd
 
 SYSTEMD_SERVICE_${PN} = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'rauc-hawkbit-updater.service', '', d)}"
 
@@ -17,6 +17,9 @@ PACKAGECONFIG ??= " \
     ${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)} \
 "
 PACKAGECONFIG[systemd] = "-DWITH_SYSTEMD=ON,,systemd"
+
+USERADD_PACKAGES = "${PN}"
+USERADD_PARAM_${PN} = "--system --home-dir / --no-create-home --shell /bin/false rauc-hawkbit"
 
 DEPENDS = "curl glib-2.0-native json-glib"
 


### PR DESCRIPTION
Add a system user "rauc-hawkbit" that is used by the systemd service of rauc-hawkbit-updater.

This fixes https://github.com/rauc/rauc-hawkbit-updater/issues/44.