### PR TITLE
bundle: Remove the do_package_write_* tasks

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -86,9 +86,9 @@ do_populate_sysroot[noexec] = "1"
 do_package[noexec] = "1"
 do_package_qa[noexec] = "1"
 do_packagedata[noexec] = "1"
-do_package_write_ipk[noexec] = "1"
-do_package_write_deb[noexec] = "1"
-do_package_write_rpm[noexec] = "1"
+deltask do_package_write_ipk
+deltask do_package_write_deb
+deltask do_package_write_rpm
 
 RAUC_BUNDLE_COMPATIBLE  ??= "${MACHINE}-${TARGET_VENDOR}"
 RAUC_BUNDLE_VERSION     ??= "${PV}"


### PR DESCRIPTION
If ever depending on a bundle in another recipe (i.e. for embedding a
bundle in another image), you currently get missing manifest issues due
to the existing packaging tasks that do not execute and thus do not
generate any manifest:

| ERROR: test-image-1.0-r0 do_rootfs: No manifest generated from: core-bundle-minimal in [..]/core-bundle-minimal.bb

This applies the same fix as poky commit
49f7c2cd87adafb2130addedf69d5f67dc1f2a22 by simply deleting the
respective tasks.

Signed-off-by: Matthew Campbell <mcampbell@izotope.com>