### PR TITLE
classes: bundle: Expand bb macros when overriding file name

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -236,7 +236,7 @@ def write_manifest(d):
             raise bb.build.FuncFailed('Unknown image type: %s' % imgtype)
 
         if slotflags and 'rename' in slotflags:
-            imgname = slotflags.get('rename')
+            imgname = d.getVarFlag('RAUC_SLOT_%s' % slot, 'rename')
 
         manifest.write("filename=%s\n" % imgname)
         if slotflags and 'hooks' in slotflags:


### PR DESCRIPTION
When renaming files in a bundle it can be useful to allow for expansion of bitbake macros in the new file name.

Fixes #133