### PR TITLE
classes: bundle: add hook to SRC_URI in example

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -6,7 +6,9 @@
 #
 #   RAUC_BUNDLE_COMPATIBLE ?= "My Super Product"
 #   RAUC_BUNDLE_VERSION ?= "v2015-06-07-1"
-#   
+#
+#   SRC_URI += "hook.sh"
+#
 #   RAUC_BUNDLE_HOOKS[file] ?= "hook.sh"
 #   RAUC_BUNDLE_HOOKS[hooks] ?= "install-check"
 #


### PR DESCRIPTION
This file is expected to be provided by the fetcher normally, thus we
should add the required SRC_URI entry in the example.

Fixes #84