### PR TITLE
classes: bundle: Fix typo "CONVERTS_ARGS"

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -53,7 +53,7 @@
 #   BUNDLE_ARGS += ' --mksquashfs-args="-comp zstd -Xcompression-level 22" '
 #
 # Likewise, extra arguments can be passed to the convert command with
-# CONVERTS_ARGS.
+# CONVERT_ARGS.
 #
 # Additionally you need to provide a certificate and a key file
 #


### PR DESCRIPTION
Replace "CONVERTS_ARGS" with correct "CONVERT_ARGS" in the description
of the bundle.bbclass.

Signed-off-by: Martin Schwan <m.schwan@phytec.de>