### PR TITLE
rauc: rauc-service has a runtime dependency on dbus

### DIFF
--- a/recipes-core/rauc/rauc.inc
+++ b/recipes-core/rauc/rauc.inc
@@ -17,6 +17,8 @@ PACKAGECONFIG[service] = "--enable-service,--enable-service=no,dbus,${PN}-servic
 PACKAGECONFIG[network] = "--enable-network,--enable-network=no,curl"
 PACKAGECONFIG[json]    = "--enable-json,--enable-json=no,json-glib"
 
+RDEPENDS_${PN}-service += "dbus"
+
 PACKAGES =+ "${PN}-service"
 SYSTEMD_SERVICE_${PN}-service = "rauc.service"
 SYSTEMD_PACKAGES = "${PN}-service"


### PR DESCRIPTION
D-Bus is required to communicate with the RAUC service.
Especially on non-systemd distros like poky it could be the case that
there is no D-Bus at all without this explicit runtime dependency.