### PR TITLE
rauc: split package into 'rauc' for binary and 'rauc-conf' for configuration

### DIFF
--- a/recipes-core/rauc/rauc-conf.bb
+++ b/recipes-core/rauc/rauc-conf.bb
@@ -7,6 +7,9 @@ RAUC_KEYRING_URI ??= "file://${RAUC_KEYRING_FILE}"
 
 RPROVIDES:${PN} += "virtual-rauc-conf"
 
+INHIBIT_DEFAULT_DEPS = "1"
+do_compile[noexec] = "1"
+
 SRC_URI = " \
   file://system.conf \
   ${RAUC_KEYRING_URI} \

--- a/recipes-core/rauc/rauc-conf.bb
+++ b/recipes-core/rauc/rauc-conf.bb
@@ -1,0 +1,30 @@
+SUMMARY = "RAUC system configuration & verification keyring"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+RAUC_KEYRING_FILE ??= "ca.cert.pem"
+RAUC_KEYRING_URI ??= "file://${RAUC_KEYRING_FILE}"
+
+RPROVIDES:${PN} += "virtual-rauc-conf"
+
+SRC_URI = " \
+  file://system.conf \
+  ${RAUC_KEYRING_URI} \
+  "
+
+do_install () {
+        # Create rauc config dir
+        # Warn if system configuration was not overwritten
+        if ! grep -q "^[^#]" ${WORKDIR}/system.conf; then
+                bbwarn "Please overwrite example system.conf with a project specific one!"
+        fi
+        install -d ${D}${sysconfdir}/rauc
+        install -m 0644 ${WORKDIR}/system.conf ${D}${sysconfdir}/rauc/system.conf
+
+        # Warn if CA file was not overwritten
+        if ! grep -q "^[^#]" ${WORKDIR}/${RAUC_KEYRING_FILE}; then
+                bbwarn "Please overwrite example ca.cert.pem with a project specific one, or set the RAUC_KEYRING_FILE variable with your file!"
+        fi
+        install -d ${D}${sysconfdir}/rauc/
+        install -m 0644 ${WORKDIR}/${RAUC_KEYRING_FILE} ${D}${sysconfdir}/rauc/
+}

--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -1,11 +1,10 @@
 RAUC_KEYRING_FILE ??= "ca.cert.pem"
 RAUC_KEYRING_URI ??= "file://${RAUC_KEYRING_FILE}"
 
-RRECOMMENDS:${PN} = "squashfs-tools"
+RRECOMMENDS:${PN} += "virtual-rauc-conf"
+RRECOMMENDS:${PN} += "squashfs-tools"
 
 SRC_URI:append = " \
-  file://system.conf \
-  ${RAUC_KEYRING_URI} \
   file://rauc-mark-good.service \
   file://rauc-mark-good.init \
   "
@@ -21,21 +20,6 @@ inherit systemd update-rc.d
 
 do_install () {
 	meson_do_install
-
-        # Create rauc config dir
-        # Warn if system configuration was not overwritten
-        if ! grep -q "^[^#]" ${WORKDIR}/system.conf; then
-                bbwarn "Please overwrite example system.conf with a project specific one!"
-        fi
-        install -d ${D}${sysconfdir}/rauc
-        install -m 0644 ${WORKDIR}/system.conf ${D}${sysconfdir}/rauc/system.conf
-
-        # Warn if CA file was not overwritten
-        if ! grep -q "^[^#]" ${WORKDIR}/${RAUC_KEYRING_FILE}; then
-                bbwarn "Please overwrite example ca.cert.pem with a project specific one, or set the RAUC_KEYRING_FILE variable with your file!"
-        fi
-        install -d ${D}${sysconfdir}/rauc/
-        install -m 0644 ${WORKDIR}/${RAUC_KEYRING_FILE} ${D}${sysconfdir}/rauc/
 
         install -d ${D}${systemd_unitdir}/system/
         install -m 0644 ${WORKDIR}/rauc-mark-good.service ${D}${systemd_unitdir}/system/


### PR DESCRIPTION
rauc: split package into 'rauc' for binary and 'rauc-conf' for configuration

This allows to build 'rauc' with default TUNE_PKGARCH while only 'rauc-conf' needs to be build for MACHINE_ARCH as it contains MACHINE-specific configuration.

Another point is that the RAUC configuration may not only by MACHINE-specific but may also differ between images (for the same MACHINE).

The rauc target package now `RRECOMMENDS` rauc-conf to pull this in by default.

For providing your own configuration, either bbappend the existing rauc-conf recipe, write a new one that provides 'virtual-rauc-conf' and set `PREFERRED_PROVIDER_virtual-rauc-conf` or just write a custom one and add it to your image's `IMAGE_INSTALL` list (or any packagegroup).

Either way, this requires migration in your rauc recipe(s)!