### PR TITLE
classes: bundle: Enable pseudo for rauc convert

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -330,7 +330,7 @@ do_bundle() {
 		if ! [ -x "$(command -v fakeroot)" ]; then
 			ln -sf ${STAGING_DIR_NATIVE}${bindir}/pseudo ${STAGING_DIR_NATIVE}${bindir}/fakeroot
 		fi
-		PSEUDO_PREFIX=${STAGING_DIR_NATIVE}/usr ${STAGING_DIR_NATIVE}${bindir}/rauc convert \
+		PSEUDO_PREFIX=${STAGING_DIR_NATIVE}/usr PSEUDO_DISABLED=0 ${STAGING_DIR_NATIVE}${bindir}/rauc convert \
 			--debug \
 			--cert=${RAUC_CERT_FILE} \
 			--key=${RAUC_KEY_FILE} \


### PR DESCRIPTION
Enable the pseudo command for rauc convert by setting the appropriate environment variable. Otherwise casync bundle contents may not have the correct permissions upon extraction.

Fixes https://github.com/rauc/rauc/issues/598