### PR TITLE
bundle.bbclass: fixes for collecting artifacts

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -250,9 +250,11 @@ def write_manifest(d):
 
         bundle_imgpath = "%s/%s" % (bundle_path, imgname)
         bb.note("adding image to bundle dir: '%s'" % imgname)
-        shutil.copy(d.expand("${DEPLOY_DIR_IMAGE}/%s") % imgsource, bundle_imgpath)
-        if not os.path.exists(bundle_imgpath):
-            raise bb.build.FuncFailed('Failed creating symlink to %s' % imgname)
+        searchpath = d.expand("${DEPLOY_DIR_IMAGE}/%s") % imgsource
+        if os.path.isfile(searchpath):
+            shutil.copy(searchpath, bundle_imgpath)
+        else:
+            raise bb.fatal("Failed adding image '%s' to bundle: not present in DEPLOY_DIR_IMAGE" % imgsource)
 
     manifest.close()
 

--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -249,9 +249,6 @@ def write_manifest(d):
         manifest.write("\n")
 
         bundle_imgpath = "%s/%s" % (bundle_path, imgname)
-        # Set or update symlinks to image files
-        if os.path.lexists(bundle_imgpath):
-            bb.utils.remove(bundle_imgpath)
         bb.note("adding image to bundle dir: '%s'" % imgname)
         shutil.copy(d.expand("${DEPLOY_DIR_IMAGE}/%s") % imgsource, bundle_imgpath)
         if not os.path.exists(bundle_imgpath):

--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -291,6 +291,8 @@ python do_configure() {
         bb.error("extra file '%s' neither found in workdir nor in deploy dir!" % file)
 }
 
+do_configure[cleandirs] = "${BUNDLE_DIR}"
+
 BUNDLE_BASENAME ??= "${PN}"
 BUNDLE_BASENAME[doc] = "Specifies desired output base name of generated bundle."
 BUNDLE_NAME ??= "${BUNDLE_BASENAME}-${MACHINE}-${DATETIME}"


### PR DESCRIPTION
This fixes some long-existing issues with artifact fetching and error handling of bundle.bbclass.

One of them was that when modifying artifact names, an artifact from a previous build could still be in the bundle creation folder and thus in the bundle unintentionally.