### PR TITLE
classes: bundle: add WORKDIR also to regular image search space

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -254,7 +254,13 @@ def write_manifest(d):
         if os.path.isfile(searchpath):
             shutil.copy(searchpath, bundle_imgpath)
         else:
-            raise bb.fatal("Failed adding image '%s' to bundle: not present in DEPLOY_DIR_IMAGE" % imgsource)
+            searchpath = d.expand("${WORKDIR}/%s") % imgsource
+            if os.path.isfile(searchpath):
+                shutil.copy(searchpath, bundle_imgpath)
+            else:
+                raise bb.fatal('Failed to find source %s' % imgsource)
+        if not os.path.exists(bundle_imgpath):
+            raise bb.fatal("Failed adding image '%s' to bundle: not present in DEPLOY_DIR_IMAGE or WORKDIR" % imgsource)
 
     manifest.close()
 


### PR DESCRIPTION
We already have a look at `WORKDIR` when searching for
`RAUC_BUNDLE_EXTRA_FILES` artifacts.
Doing the same for images too will potential allow generating required
artifacts right from the bundle recipe run and use them as images to be
copied to `BUNDLE_DIR`.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>