### PR TITLE
rauc: add 'gpt' to PACKAGECONFIG

### DIFF
--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -70,4 +70,4 @@ RRECOMMENDS_${PN}_append = " ${PN}-mark-good"
 
 FILES_${PN}-mark-good = "${systemd_unitdir}/system/rauc-mark-good.service ${sysconfdir}/init.d/rauc-mark-good"
 
-PACKAGECONFIG ??= "service network json nocreate"
+PACKAGECONFIG ??= "service network json nocreate gpt"

--- a/recipes-core/rauc/rauc.inc
+++ b/recipes-core/rauc/rauc.inc
@@ -16,6 +16,7 @@ PACKAGECONFIG[nocreate]  = "--disable-create,--enable-create,"
 PACKAGECONFIG[service] = "--enable-service,--enable-service=no,dbus,${PN}-service"
 PACKAGECONFIG[network] = "--enable-network,--enable-network=no,curl"
 PACKAGECONFIG[json]    = "--enable-json,--enable-json=no,json-glib"
+PACKAGECONFIG[gpt]     = "--enable-gpt,--enable-gpt=no,util-linux"
 
 RDEPENDS_${PN}-service += "dbus"
 


### PR DESCRIPTION
This allows to enable atomic updates of bootloaders on primary GPT
partition. Add to defaults for the target package.

See https://rauc.readthedocs.io/en/latest/advanced.html#update-boot-partition-in-gpt

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>