### PR TITLE
deploy casync native to tools dir

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,10 @@ If you only intend to build the RAUC host tool, you may simply run::
 
 This will place the rauc binary at ``tmp/deploy/tools/rauc``.
 
+If you need to execute the ``casync`` host tool manually, you can do this by running::
+
+  bitbake casync-native -caddto_recipe_sysroot
+  oe-run-native casync-native casync --help
 
 III. Adding the RAUC Update Service to Your Device
 ==================================================


### PR DESCRIPTION
1. deploy casync native binary to tmp/deploy/tools/casync
1. bump casync source revision to 4ad9bcb94bc83ff36cfc65515107ea06a88c2dfc