### PR TITLE
rauc: update to v1.5

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -43,6 +43,10 @@
 # Optionally you can use units allowed by 'dd' e.g. 'K','kB','MB'.
 #   RAUC_SLOT_bootloader[offset] ?= "0"
 #
+# Enable building verity format bundles with
+#
+#   RAUC_BUNDLE_FORMAT = "verity"
+#
 # To add additional artifacts to the bundle you can use RAUC_BUNDLE_EXTRA_FILES
 # and RAUC_BUNDLE_EXTRA_DEPENDS.
 # For files from the WORKDIR (fetched using SRC_URI) you can write:
@@ -113,6 +117,9 @@ RAUC_BUNDLE_EXTRA_FILES[doc] = "Specifies list of additional files to add to bun
 RAUC_BUNDLE_EXTRA_DEPENDS[doc] = "Specifies list of recipes that create artifacts in DEPLOY_DIR_IMAGE. For recipes not depending on do_deploy task also <recipename>:do_<taskname> notation is supported"
 
 RAUC_CASYNC_BUNDLE ??= "0"
+
+RAUC_BUNDLE_FORMAT ??= ""
+RAUC_BUNDLE_FORMAT[doc] = "Specifies the bundle format to used (plain/verity)."
 
 # Create dependency list from images
 python __anonymous() {
@@ -185,6 +192,11 @@ def write_manifest(d):
     manifest.write(d.expand('description=${RAUC_BUNDLE_DESCRIPTION}\n'))
     manifest.write(d.expand('build=${RAUC_BUNDLE_BUILD}\n'))
     manifest.write('\n')
+
+    if d.getVar('RAUC_BUNDLE_FORMAT'):
+        manifest.write('[bundle]\n')
+        manifest.write(d.expand('format=${RAUC_BUNDLE_FORMAT}\n'))
+        manifest.write('\n')
 
     hooksflags = d.getVarFlags('RAUC_BUNDLE_HOOKS')
     have_hookfile = False

--- a/recipes-core/rauc/files/system.conf
+++ b/recipes-core/rauc/files/system.conf
@@ -15,6 +15,7 @@
 # [system]
 # compatible=My Example System
 # bootloader=<barebox|uboot|grub>
+# bundle-formats=-plain
 # 
 # [slot.rootfs.0]
 # device=/dev/mmcblkXp1

--- a/recipes-core/rauc/nativesdk-rauc_1.4.bb
+++ b/recipes-core/rauc/nativesdk-rauc_1.4.bb
@@ -1,3 +1,0 @@
-require rauc-1.4.inc
-
-inherit nativesdk

--- a/recipes-core/rauc/nativesdk-rauc_1.5.bb
+++ b/recipes-core/rauc/nativesdk-rauc_1.5.bb
@@ -1,0 +1,3 @@
+require rauc-1.5.inc
+
+inherit nativesdk

--- a/recipes-core/rauc/rauc-1.5.inc
+++ b/recipes-core/rauc/rauc-1.5.inc
@@ -2,7 +2,7 @@ require rauc.inc
 
 SRC_URI = "https://github.com/rauc/rauc/releases/download/v${PV}/rauc-${PV}.tar.xz"
 
-SRC_URI[md5sum] = "c66e8bfb82d9d3838a270abaafeea044"
-SRC_URI[sha256sum] = "85aabf214cd93a37f7ad0b3aaad89eb94facf0f3ebf6e2edca945acbca9b0967"
+SRC_URI[md5sum] = "83d86821473102682cd1ad2a4a9a7a4c"
+SRC_URI[sha256sum] = "5dfbc46e808240c5014d318cfe64f0431307c37aa79cb2b013caa12daaf96d9d"
 
 UPSTREAM_CHECK_URI = "https://github.com/${BPN}/${BPN}/releases"

--- a/recipes-core/rauc/rauc-native_1.5.bb
+++ b/recipes-core/rauc/rauc-native_1.5.bb
@@ -1,2 +1,2 @@
-require rauc-1.4.inc
+require rauc-1.5.inc
 require rauc-native.inc

--- a/recipes-core/rauc/rauc_1.5.bb
+++ b/recipes-core/rauc/rauc_1.5.bb
@@ -1,2 +1,2 @@
-require rauc-1.4.inc
+require rauc-1.5.inc
 require rauc-target.inc


### PR DESCRIPTION
Important: This fixes [CVE-2020-25860](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25860)