### PR TITLE
rauc: update to v1.5.1

### DIFF
--- a/recipes-core/rauc/nativesdk-rauc_1.5.1.bb
+++ b/recipes-core/rauc/nativesdk-rauc_1.5.1.bb
@@ -1,0 +1,3 @@
+require rauc-1.5.1.inc
+
+inherit nativesdk

--- a/recipes-core/rauc/nativesdk-rauc_1.5.bb
+++ b/recipes-core/rauc/nativesdk-rauc_1.5.bb
@@ -1,3 +1,0 @@
-require rauc-1.5.inc
-
-inherit nativesdk

--- a/recipes-core/rauc/rauc-1.5.1.inc
+++ b/recipes-core/rauc/rauc-1.5.1.inc
@@ -2,7 +2,6 @@ require rauc.inc
 
 SRC_URI = "https://github.com/rauc/rauc/releases/download/v${PV}/rauc-${PV}.tar.xz"
 
-SRC_URI[md5sum] = "83d86821473102682cd1ad2a4a9a7a4c"
-SRC_URI[sha256sum] = "5dfbc46e808240c5014d318cfe64f0431307c37aa79cb2b013caa12daaf96d9d"
+SRC_URI[sha256sum] = "d4ea009ce702bcb083d942398ccfedec959c6bbb7adc0fd77ae9314ce11d9d91"
 
 UPSTREAM_CHECK_URI = "https://github.com/${BPN}/${BPN}/releases"

--- a/recipes-core/rauc/rauc-native_1.5.1.bb
+++ b/recipes-core/rauc/rauc-native_1.5.1.bb
@@ -1,2 +1,2 @@
-require rauc-1.5.inc
+require rauc-1.5.1.inc
 require rauc-native.inc

--- a/recipes-core/rauc/rauc_1.5.1.bb
+++ b/recipes-core/rauc/rauc_1.5.1.bb
@@ -1,2 +1,2 @@
-require rauc-1.5.inc
+require rauc-1.5.1.inc
 require rauc-target.inc


### PR DESCRIPTION
Update for 1.5 with casync bundle manifest generation fix and
compatibility fixes for older glib versions, kernel headers, etc.

Drop deprecated md5sum hash.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>