### PR TITLE
rauc-native.inc: reorder inherit to silence recently added qa check

### DIFF
--- a/recipes-core/rauc/rauc-native.inc
+++ b/recipes-core/rauc/rauc-native.inc
@@ -1,4 +1,4 @@
-inherit native deploy
+inherit deploy native
 
 DEPENDS = "openssl-native glib-2.0-native"
 RRECOMMENDS_${PN} = "squashfs-tools-native"


### PR DESCRIPTION
avoid this qa warning:
QA Issue: rauc-native: native/nativesdk class is not inherited last,
this can result in unexpected behaviour.  [native-last]