### PR TITLE
python3-aiohttp: add missing RDEPENDs

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,6 +9,10 @@ BBFILE_COLLECTIONS += "rauc"
 BBFILE_PATTERN_rauc = "^${LAYERDIR}/"
 BBFILE_PRIORITY_rauc = "6"
 
+BBFILES_DYNAMIC += " \
+        meta-python:${LAYERDIR}/dynamic-layers/python/recipes-*/*/*.bb \
+        meta-python:${LAYERDIR}/dynamic-layers/python/recipes-*/*/*.bbappend"
+
 LAYERDEPENDS_rauc = "core"
 
 # meta-python is needed to build/run hawkbit-client

--- a/dynamic-layers/python/recipes-devtools/python/python3-aiohttp_3.6.2.bbappend
+++ b/dynamic-layers/python/recipes-devtools/python/python3-aiohttp_3.6.2.bbappend
@@ -1,0 +1,5 @@
+RDEPENDS_${PN} += "\
+    ${PYTHON_PN}-html \
+    ${PYTHON_PN}-json \
+    ${PYTHON_PN}-netserver \
+"


### PR DESCRIPTION
This performs the changes done in meta-oe upstream for master and
gatesgarth. See:

https://lists.openembedded.org/g/openembedded-devel/message/88194

The proper fix is to backport these patches to meta-oe dunfell branch.
Then this commit would become obsolete.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>