### PR TITLE
bundle.bbclass: fix task ordering for rm_work

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -376,7 +376,7 @@ do_bundle() {
 do_bundle[dirs] = "${B}"
 do_bundle[cleandirs] = "${B}"
 
-addtask bundle after do_configure before do_build
+addtask bundle after do_configure
 
 inherit deploy
 


### PR DESCRIPTION
Do not let 'bundle' task be explicitly ordered before do_build as this
will add a dependency

  "update-bundle-dev.do_rm_work" -> "update-bundle-dev.do_bundle"

which will always retrigger do_bundle task when rm_work is invoked.

The explanation for this is that do_bundle is not an sstate-enabled task.
Thus while rm_work will erase the task output it will also triggers its
rebuild then.

Triggering of do_bundle is ensured by do_deploy task that depends on
do_bundle and is triggered by do_build.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>