### PR TITLE
Add the possibility to add directories to bundle

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -313,11 +313,19 @@ python do_configure() {
             bb.note("adding extra file from deploy dir to bundle dir: '%s'" % file)
             shutil.copy(searchpath, destpath)
             continue
+        elif os.path.isdir(searchpath):
+            bb.note("adding extra directory from deploy dir to bundle dir: '%s'" % file)
+            shutil.copytree(searchpath, destpath, dirs_exist_ok=True)
+            continue
 
         searchpath = d.expand("${WORKDIR}/%s") % file
         if os.path.isfile(searchpath):
             bb.note("adding extra file from workdir to bundle dir: '%s'" % file)
             shutil.copy(searchpath, destpath)
+            continue
+        elif os.path.isdir(searchpath):
+            bb.note("adding extra directory from workdir to bundle dir: '%s'" % file)
+            shutil.copytree(searchpath, destpath, dirs_exist_ok=True)
             continue
 
         bb.error("extra file '%s' neither found in workdir nor in deploy dir!" % file)


### PR DESCRIPTION
Example usage:
```
SRC_URI_append := " file://hook \
                    file://service.py \
                    file://scripts \
                  "

RAUC_BUNDLE_EXTRA_FILES += "service.py \
                            scripts \
                           "
```
Where scripts is a directory containing files and subdirectories that
will be included in the rauc bundle.