### PR TITLE
classes: bundle: drop some unneded noexec tasks

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -92,9 +92,9 @@ do_fetch[cleandirs] = "${S}"
 do_patch[noexec] = "1"
 do_compile[noexec] = "1"
 do_install[noexec] = "1"
-do_populate_sysroot[noexec] = "1"
+deltask do_populate_sysroot
 do_package[noexec] = "1"
-do_package_qa[noexec] = "1"
+deltask do_package_qa
 do_packagedata[noexec] = "1"
 deltask do_package_write_ipk
 deltask do_package_write_deb


### PR DESCRIPTION
This basically does the same as poky commits do for image.bbclass:

* 7fb3c6a40adb0f6c3032b0a5628c8a56b0e7bd4a
  "image/packagegroup/populate_sdk: Drop do_populate_sysroot task properly"
  (OE-Core: bd7d0314038a4c1a8e8c9ebdb7194f8e17db3fe)

* 60662a2117373648a0a41b3556e180f7a7350a47
  "image/kernelsrc/packagegroups/recipes: Remove uneeded noexec tasks"
  (OE-Core 4e6ee37e09c60e83c0dfd844ba9cf8a07507f099)

As we do not execute this task, we do not generate a manifest here etc.
Fully drop them to simplify task dependencies.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>