### PR TITLE
classes: bundle: Allow to change Casync bundle name

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -326,14 +326,24 @@ python do_configure() {
 do_configure[cleandirs] = "${BUNDLE_DIR}"
 
 BUNDLE_BASENAME ??= "${PN}"
-BUNDLE_BASENAME[doc] = "Specifies desired output base name of generated bundle."
+BUNDLE_BASENAME[doc] = "Specifies desired output base name of generated RAUC bundle."
 BUNDLE_NAME ??= "${BUNDLE_BASENAME}-${MACHINE}-${DATETIME}"
-BUNDLE_NAME[doc] = "Specifies desired full output name of generated bundle."
+BUNDLE_NAME[doc] = "Specifies desired full output name of generated RAUC bundle."
 # Don't include the DATETIME variable in the sstate package sigantures
 BUNDLE_NAME[vardepsexclude] = "DATETIME"
 BUNDLE_LINK_NAME ??= "${BUNDLE_BASENAME}-${MACHINE}"
 BUNDLE_EXTENSION ??= ".raucb"
-BUNDLE_EXTENSION[doc] = "Specifies desired custom filename extension of generated bundle"
+BUNDLE_EXTENSION[doc] = "Specifies desired custom filename extension of generated RAUC bundle."
+
+CASYNC_BUNDLE_BASENAME ??= "casync-${BUNDLE_BASENAME}"
+CASYNC_BUNDLE_BASENAME[doc] = "Specifies desired output base name of generated RAUC casync bundle."
+CASYNC_BUNDLE_NAME ??= "${CASYNC_BUNDLE_BASENAME}-${MACHINE}-${DATETIME}"
+CASYNC_BUNDLE_NAME[doc] = "Specifies desired full output name of generated RAUC casync bundle."
+# Don't include the DATETIME variable in the sstate package sigantures
+CASYNC_BUNDLE_NAME[vardepsexclude] = "DATETIME"
+CASYNC_BUNDLE_LINK_NAME ??= "${CASYNC_BUNDLE_BASENAME}-${MACHINE}"
+CASYNC_BUNDLE_EXTENSION ??= "${BUNDLE_EXTENSION}"
+CASYNC_BUNDLE_EXTENSION[doc] = "Specifies desired custom filename extension of generated RAUC casync bundle."
 
 do_bundle() {
 	if [ -z "${RAUC_KEY_FILE}" ]; then
@@ -386,10 +396,10 @@ do_deploy() {
 	ln -sf ${BUNDLE_NAME}${BUNDLE_EXTENSION} ${DEPLOYDIR}/${BUNDLE_LINK_NAME}${BUNDLE_EXTENSION}
 
 	if [ ${RAUC_CASYNC_BUNDLE} -eq 1 ]; then
-		install ${B}/casync-bundle${BUNDLE_EXTENSION} ${DEPLOYDIR}/casync-${BUNDLE_NAME}${BUNDLE_EXTENSION}
-		cp -r ${B}/casync-bundle.castr ${DEPLOYDIR}/casync-${BUNDLE_NAME}.castr
-		ln -sf casync-${BUNDLE_NAME}${BUNDLE_EXTENSION} ${DEPLOYDIR}/casync-${BUNDLE_LINK_NAME}${BUNDLE_EXTENSION}
-		ln -sf casync-${BUNDLE_NAME}.castr ${DEPLOYDIR}/casync-${BUNDLE_LINK_NAME}.castr
+		install ${B}/casync-bundle.raucb ${DEPLOYDIR}/${CASYNC_BUNDLE_NAME}${CASYNC_BUNDLE_EXTENSION}
+		cp -r ${B}/casync-bundle.castr ${DEPLOYDIR}/${CASYNC_BUNDLE_NAME}.castr
+		ln -sf ${CASYNC_BUNDLE_NAME}${CASYNC_BUNDLE_EXTENSION} ${DEPLOYDIR}/${CASYNC_BUNDLE_LINK_NAME}${CASYNC_BUNDLE_EXTENSION}
+		ln -sf ${CASYNC_BUNDLE_NAME}.castr ${DEPLOYDIR}/${CASYNC_BUNDLE_LINK_NAME}.castr
 	fi
 }
 


### PR DESCRIPTION
Let user to customize Casync bundle name using CASYNC_BUNDLE_*NAME set
of variables similarly to BUNDLE_*NAME used for conventional bundles.
New set has similar dependency scheme except that it uses new variable
CASYNC_BUNDLE_BASENAME instead of BUNDLE_BASENAME.

The CASYNC_BUNDLE_BASENAME defaults to "casync-${BUNDLE_BASENAME}" so
this patch makes no changes in bundle names until user would like to
provide custom ones.

Also fix inconsistence in ${B}/casync-bundle.raucb name in do_bundle
and do_deploy tasks.

Signed-off-by: Vitaly Kuzmichev <vkuzmichev@dev.rtsoft.ru>