### PR TITLE
classes: bundle: add support to find imagesource in subdir

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -176,6 +176,7 @@ DEPENDS += "${@bb.utils.contains('RAUC_CASYNC_BUNDLE', '1', 'virtual/fakeroot-na
 def write_manifest(d):
     import shutil
     import subprocess
+    from pathlib import PurePath
 
     machine = d.getVar('MACHINE')
     bundle_path = d.expand("${BUNDLE_DIR}")
@@ -262,6 +263,8 @@ def write_manifest(d):
             if slotflags.get('offset') == '':
                 imgoffset = '0'
 
+        # Keep only the image name in case the image is in a $DEPLOY_DIR_IMAGE subdirectory
+        imgname = PurePath(imgname).name
         manifest.write("filename=%s\n" % imgname)
         if slotflags and 'hooks' in slotflags:
             if not have_hookfile:


### PR DESCRIPTION
In some cases the image to include in RAUC bundle
may be inside a $DEPLOY_DIR_IMAGE subdirectory
and imgname variable will contains it in the path.
The result is a failure at the image copy and the
filename manifest field also contains it.
This change wrap the imgname with a Python PurePath
to keep only the image filename instead of full path.

Signed-off-by: Jarsop <jarsop@outlook.com>