### PR TITLE
rauc: rauc-mark-good: improve service unit

### DIFF
--- a/recipes-core/rauc/files/rauc-mark-good.service
+++ b/recipes-core/rauc/files/rauc-mark-good.service
@@ -1,12 +1,14 @@
 [Unit]
-Description=Rauc Good-marking Service
+Description=RAUC Good-marking Service
+ConditionKernelCommandLine=|bootchooser.active
+ConditionKernelCommandLine=|rauc.slot
 After=boot-complete.target
 Requires=boot-complete.target
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=@BINDIR@/rauc status mark-good
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
Make the rauc-mark-good.service run only if `bootchooser.active` or `rauc.slot` are set in the kernel command line. During
debugging/development, boot from NFS or non-bootchooser boots might be used. In these cases `rauc status mark-good` will fail.

`RemainAfterExit=yes` allows systemd to start dependencies only after `rauc status mark-good` has succeeded.

While at it, use the official RAUC spelling and remove the trailing empty line.