### PR TITLE
classes: bundle: Trust environment for "rauc convert"

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -403,6 +403,7 @@ do_bundle() {
 		fi
 		PSEUDO_PREFIX=${STAGING_DIR_NATIVE}/usr PSEUDO_DISABLED=0 ${STAGING_DIR_NATIVE}${bindir}/rauc convert \
 			--debug \
+			--trust-environment \
 			--cert=${RAUC_CERT_FILE} \
 			--key=${RAUC_KEY_FILE} \
 			--keyring=${RAUC_KEYRING_FILE} \


### PR DESCRIPTION
Trust the environment RAUC is executed in when converting bundles. This fixes the following error message:

> initial check_bundle_access failed with: unable to find mounted device for bundle

---
I am keeping this PR as a draft for the moment, until https://github.com/rauc/rauc/pull/770 is merged.