### PR TITLE
casync: inherit pkgconfig

### DIFF
--- a/recipes-casync/casync/casync_git.bb
+++ b/recipes-casync/casync/casync_git.bb
@@ -14,7 +14,7 @@ SRC_URI = " \
 
 S = "${WORKDIR}/git"
 
-inherit meson
+inherit meson pkgconfig
 
 EXTRA_OEMESON += "-Dselinux=false -Dman=false -Dudevrulesdir=${nonarch_base_libdir}/udev/rules.d/"
 


### PR DESCRIPTION
The casync recipe now requires to inherit pkgconfig like seen with
latest meta-qt5 recipes, otherwise the build fails with:

    ../git/meson.build:114:0: ERROR: Pkg-config binary for machine MachineChoice.HOST not found. Giving up.

Signed-off-by: Vivien Didelot <vdidelot@pbsc.com>