### PR TITLE
recipes: Update SRC_URI branch and protocols

### DIFF
--- a/recipes-casync/casync/casync_git.bb
+++ b/recipes-casync/casync/casync_git.bb
@@ -9,7 +9,7 @@ SRCREV = "a8f6c841ccfe59ca8c68aad64df170b64042dce8"
 PV = "2+git${SRCPV}"
 
 SRC_URI = " \
-    git://github.com/systemd/casync.git;protocol=https \
+    git://github.com/systemd/casync.git;protocol=https;branch=master \
     "
 
 S = "${WORKDIR}/git"

--- a/recipes-core/rauc/rauc-git.inc
+++ b/recipes-core/rauc/rauc-git.inc
@@ -3,7 +3,7 @@ require rauc.inc
 PR = "r0"
 
 SRC_URI = " \ 
-  git://github.com/rauc/rauc.git;protocol=https \
+  git://github.com/rauc/rauc.git;protocol=https;branch=master \
   "
 
 PV = "1.1+git${SRCPV}"

--- a/recipes-support/rauc-hawkbit-updater/rauc-hawkbit-updater_git.bb
+++ b/recipes-support/rauc-hawkbit-updater/rauc-hawkbit-updater_git.bb
@@ -1,6 +1,6 @@
 include rauc-hawkbit-updater.inc
 
-SRC_URI = "git://github.com/rauc/rauc-hawkbit-updater.git;protocol=https"
+SRC_URI = "git://github.com/rauc/rauc-hawkbit-updater.git;protocol=https;branch=master"
 SRCREV = "c59cd13c2f7a8d6c1c1827f4282d11d0a9b8e465"
 S = "${WORKDIR}/git"
 PV = "1.0+git${SRCPV}"

--- a/recipes-support/rauc-hawkbit/rauc-hawkbit_git.bb
+++ b/recipes-support/rauc-hawkbit/rauc-hawkbit_git.bb
@@ -6,7 +6,7 @@ SUMMARY = "hawkBit client for RAUC"
 DEPENDS = "python3-setuptools-scm-native"
 
 SRC_URI = " \
-    git://github.com/rauc/rauc-hawkbit.git;protocol=https \
+    git://github.com/rauc/rauc-hawkbit.git;protocol=https;branch=master \
     file://rauc-hawkbit.service \
 "
 


### PR DESCRIPTION
Update the SRC_URIs to include a branch and to include a protocol for
GitHub. This was performed using the convert script from
openembedded-core.

Signed-off-by: Marcel Hamer <marcel@solidxs.se>