### PR TITLE
rauc: move 'streaming' PACKAGECONFIG option to common includes

### DIFF
--- a/recipes-core/rauc/rauc-git.inc
+++ b/recipes-core/rauc/rauc-git.inc
@@ -12,7 +12,3 @@ SRCREV = "3963103bac7dc872c5ee42a2924a39474278af39"
 RAUC_USE_DEVEL_VERSION[doc] = "Global switch to enable RAUC development (git) version."
 RAUC_USE_DEVEL_VERSION ??= "-1"
 DEFAULT_PREFERENCE ??= "${RAUC_USE_DEVEL_VERSION}"
-
-PACKAGECONFIG[streaming] = "--enable-streaming,--enable-streaming=no,libnl"
-
-PACKAGECONFIG:class-target ??= "service network streaming json nocreate gpt"

--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -70,4 +70,4 @@ RRECOMMENDS:${PN}:append = " ${PN}-mark-good"
 
 FILES:${PN}-mark-good = "${systemd_unitdir}/system/rauc-mark-good.service ${sysconfdir}/init.d/rauc-mark-good"
 
-PACKAGECONFIG ??= "service network json nocreate gpt"
+PACKAGECONFIG ??= "service network streaming json nocreate gpt"

--- a/recipes-core/rauc/rauc.inc
+++ b/recipes-core/rauc/rauc.inc
@@ -14,6 +14,7 @@ EXTRA_OECONF += "\
 
 PACKAGECONFIG[nocreate]  = "--disable-create,--enable-create,"
 PACKAGECONFIG[service] = "--enable-service,--enable-service=no,dbus,${PN}-service"
+PACKAGECONFIG[streaming] = "--enable-streaming,--enable-streaming=no,libnl"
 PACKAGECONFIG[network] = "--enable-network,--enable-network=no,curl"
 PACKAGECONFIG[json]    = "--enable-json,--enable-json=no,json-glib"
 PACKAGECONFIG[gpt]     = "--enable-gpt,--enable-gpt=no,util-linux"


### PR DESCRIPTION
With v1.7 being released and available as recipe, the streaming option
can be enabled for all supported RAUC recipes.
Thus move the option to rauc.inc and enable streaming support in the
default target PACKAGECONFIG.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>