### PR TITLE
classes: bundle: hack in support for rm_work

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -145,6 +145,7 @@ python __anonymous() {
 
         if imgtype == 'image':
             d.appendVarFlag('do_unpack', 'depends', ' ' + image + ':do_image_complete')
+            d.appendVarFlag('do_rm_work_all', 'depends', ' ' + image + ':do_rm_work_all')
         else:
             d.appendVarFlag('do_unpack', 'depends', ' ' + image + ':do_deploy')
 


### PR DESCRIPTION
Building a bundle with having 'rm_work' class enabled did not lead to
rm_work tasks being run for recipes that were dependencies of the rootfs
image recipe used.
This was something between annoying and unexpected and the only
workaround so far was to also explicitly build the root file system
recipe used by the bundle which triggered rm_work correctly.

The reason why rm_work is not triggered by bundle builds lies in the
way the bundle class depends on images.
For depending on images we must depend on the 'do_image_complete' task
instead of 'do_build' (like one would for normal packages).

Now, the rm_work class works by injecting its tasks as dependencies of
'do_build'. It adds a high-level 'do_rm_work_all' task that itself
depends (via recrdeptasks) on the actual 'do_rm_work' worker tasks of
dependency packages.
But, since the image recipe is not pulled in via a 'do_build'
dependency, it is also not treated as a dependency of the bundle recipe
and thus neither a dependency on its 'do_rm_work' task nor on the ones
of its dependent packages is added.

Since we cannot use do_build, we use a little hack and simply add an
explicit dependency from the bundle's do_rm_work_all task to the image
recipe's do_rm_work_all task.

Since both task do not exist if rm_work is not used, it should be safe
to define this dependency unconditionally.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>