### PR TITLE
rauc-git: update recipe version to 1.8

### DIFF
--- a/recipes-core/rauc/rauc-git.inc
+++ b/recipes-core/rauc/rauc-git.inc
@@ -4,10 +4,10 @@ SRC_URI = " \
   git://github.com/rauc/rauc.git;protocol=https;branch=master \
   "
 
-PV = "1.7+git${SRCPV}"
+PV = "1.8+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-SRCREV = "b2ee22acd0480ce98a5ba8b231af064405ff4bee"
+SRCREV = "bfbf94caf4e3deb3fcef69c8c14a3ac673707153"
 
 RAUC_USE_DEVEL_VERSION[doc] = "Global switch to enable RAUC development (git) version."
 RAUC_USE_DEVEL_VERSION ??= "-1"


### PR DESCRIPTION
This has been forgotten in #240.