### PR TITLE
classes: bundle: Allow parsing var flags offset, hooks and adaptive

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -263,7 +263,7 @@ def write_manifest(d):
             imgname = d.getVarFlag('RAUC_SLOT_%s' % slot, 'rename')
         if slotflags and 'offset' in slotflags:
             padding = 'seek'
-            imgoffset = slotflags.get('offset')
+            imgoffset = d.getVarFlag('RAUC_SLOT_%s' % slot, 'offset')
             if imgoffset:
                 sign, magnitude = imgoffset[:1], imgoffset[1:]
                 if sign == '+':
@@ -281,9 +281,9 @@ def write_manifest(d):
         if slotflags and 'hooks' in slotflags:
             if not have_hookfile:
                 bb.warn("A hook is defined for slot %s, but RAUC_BUNDLE_HOOKS[file] is not defined" % slot)
-            manifest.write("hooks=%s\n" % slotflags.get('hooks'))
+            manifest.write("hooks=%s\n" % d.getVarFlag('RAUC_SLOT_%s' % slot, 'hooks'))
         if slotflags and 'adaptive' in slotflags:
-            manifest.write("adaptive=%s\n" % slotflags.get('adaptive'))
+            manifest.write("adaptive=%s\n" % d.getVarFlag('RAUC_SLOT_%s' % slot, 'adaptive'))
         manifest.write("\n")
 
         bundle_imgpath = "%s/%s" % (bundle_path, imgname)


### PR DESCRIPTION
Allow for BitBake variable parsing inside the variable flags "offset", "hooks" and "adaptive". To enable this, use d.getVarFlag() instead of the builtin get() method.