### PR TITLE
rauc-native: do not deploy tool anymore

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,12 +59,14 @@ other layers needed. e.g.::
     "
 
 
-II. Building RAUC Host Tool
-===========================
+II. Building and Using RAUC Host Tool
+=====================================
 
-If you only intend to build the RAUC host tool, you may simply run::
+If you intend to build and use RAUC as a host tool from you BSP, e.g. for
+calling ``rauc info`` on your built bundle, simply run::
 
-  bitbake rauc-native
+  bitbake rauc-native -caddto_recipe_sysroot
+  oe-run-native rauc-native rauc info --keyring=/path/to/keyring.pem tmp/deploy/images/<machine>/<bundle-name>.raucb
 
 This will place the rauc binary at ``tmp/deploy/tools/rauc``.
 

--- a/recipes-core/rauc/rauc-native.inc
+++ b/recipes-core/rauc/rauc-native.inc
@@ -1,14 +1,4 @@
-inherit deploy native
+inherit native
 
 DEPENDS = "openssl-native glib-2.0-native"
 RRECOMMENDS:${PN} = "squashfs-tools-native"
-
-do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
-
-do_deploy() {
-    install -d ${DEPLOY_DIR_TOOLS}
-    install -m 0755 ${B}/rauc ${DEPLOY_DIR_TOOLS}/rauc-${PV}
-    ln -sf rauc-${PV} ${DEPLOY_DIR_TOOLS}/rauc
-}
-
-addtask deploy before do_package after do_install


### PR DESCRIPTION
Using tmp/deploy/tools for deploying native tools is nowadays used hardly anywhere. It also has some severe drawkbacks since it relies on having matching shared libs in the host system.

Now, with poky having moved to openssl 3.0 and most distros have not, yet, this became unusable for most people, anyway.

They will run into this error:
> tmp/deploy/tools/rauc: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory

The recommended way of using native tools in Yocto is to use oe-run-native. Document this in the README instead of the old deploy-way..

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>