### PR TITLE
rauc: move rauc-service to rauc-target.inc

### DIFF
--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -70,4 +70,15 @@ RRECOMMENDS:${PN}:append = " ${PN}-mark-good"
 
 FILES:${PN}-mark-good = "${systemd_unitdir}/system/rauc-mark-good.service ${sysconfdir}/init.d/rauc-mark-good"
 
+PACKAGES =+ "${PN}-service"
+SYSTEMD_SERVICE:${PN}-service = "rauc.service"
+SYSTEMD_PACKAGES = "${PN}-service"
+RDEPENDS:${PN}-service += "dbus"
+
+FILES:${PN}-service = "\
+  ${systemd_unitdir}/system/rauc.service \
+  ${datadir}/dbus-1/system.d/de.pengutronix.rauc.conf \
+  ${datadir}/dbus-1/system-services/de.pengutronix.rauc.service \
+  "
+
 PACKAGECONFIG ??= "service network streaming json nocreate gpt"

--- a/recipes-core/rauc/rauc.inc
+++ b/recipes-core/rauc/rauc.inc
@@ -19,18 +19,6 @@ PACKAGECONFIG[network] = "--enable-network,--enable-network=no,curl"
 PACKAGECONFIG[json]    = "--enable-json,--enable-json=no,json-glib"
 PACKAGECONFIG[gpt]     = "--enable-gpt,--enable-gpt=no,util-linux"
 
-RDEPENDS:${PN}-service += "dbus"
-
-PACKAGES =+ "${PN}-service"
-SYSTEMD_SERVICE:${PN}-service = "rauc.service"
-SYSTEMD_PACKAGES = "${PN}-service"
-
-FILES:${PN}-service = "\
-  ${systemd_unitdir}/system/rauc.service \
-  ${datadir}/dbus-1/system.d/de.pengutronix.rauc.conf \
-  ${datadir}/dbus-1/system-services/de.pengutronix.rauc.service \
-  "
-
 FILES:${PN}-dev += "\
   ${datadir}/dbus-1/interfaces/de.pengutronix.rauc.Installer.xml \
   "


### PR DESCRIPTION
The service is only relevant for the target and should thus not be defined in the generic rauc.inc.

This also fixes an actual bug since the dependency

| RDEPENDS:${PN}-service += "dbus"

applies to the target package as it applies to -native and nativesdk- as well. And the latter two are clearly wrong.