### PR TITLE
Update layer compat to mickledore

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,7 +17,7 @@ LAYERRECOMMENDS_rauc = "meta-python"
 # meta-filesystems is needed to build cascync with fuse support (the default)
 LAYERRECOMMENDS_rauc += "meta-filesystems"
 
-LAYERSERIES_COMPAT_rauc = "langdale"
+LAYERSERIES_COMPAT_rauc = "mickledore"
 
 # Sanity check for meta-rauc layer.
 # Setting SKIP_META_RAUC_FEATURE_CHECK to "1" would skip the bbappend files check.


### PR DESCRIPTION
Upstream oe core has updated the release name from langdale to mickledore.

Signed-off-by: Theodore A. Roth <troth@openavr.org>