### PR TITLE
Fix nativesdk build

### DIFF
--- a/recipes-core/rauc/nativesdk-rauc.inc
+++ b/recipes-core/rauc/nativesdk-rauc.inc
@@ -1,0 +1,1 @@
+inherit nativesdk

--- a/recipes-core/rauc/nativesdk-rauc.inc
+++ b/recipes-core/rauc/nativesdk-rauc.inc
@@ -1,1 +1,6 @@
+do_install:append() {
+	rm -rf ${D}${nonarch_base_libdir}
+	rm -rf ${D}${datadir}/dbus-1
+}
+
 inherit nativesdk

--- a/recipes-core/rauc/nativesdk-rauc_1.8.bb
+++ b/recipes-core/rauc/nativesdk-rauc_1.8.bb
@@ -1,4 +1,3 @@
 require rauc.inc
 require rauc-1.8.inc
-
-inherit nativesdk
+require nativesdk-rauc.inc

--- a/recipes-core/rauc/nativesdk-rauc_git.bb
+++ b/recipes-core/rauc/nativesdk-rauc_git.bb
@@ -1,4 +1,3 @@
 require rauc.inc
 require rauc-git.inc
-
-inherit nativesdk
+require nativesdk-rauc.inc


### PR DESCRIPTION
With https://github.com/rauc/meta-rauc/commit/815e9130f9aee5c7e6f5c027a3102bc79ada9082 ("rauc: move rauc-service to rauc-target.inc") the FILES
variable was modified to not collect the dbus- and service-related files
installed by RAUC anymore.

This causes the nativesdk build to fail. Since the service files are
pointless in a nativesdk anyway, we simple remove them with a
do_install:append().

Fixes:

```
ERROR: nativesdk-rauc-1.8-r0 do_package: QA Issue: nativesdk-rauc: Files/directories were installed but not shipped in any package:
  /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/lib
  /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/usr/share/dbus-1
  /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/usr/share/dbus-1/system.d
  /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/usr/share/dbus-1/system-services
  /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/usr/share/dbus-1/system.d/de.pengutronix.rauc.conf
  /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/usr/share/dbus-1/system-services/de.pengutronix.rauc.service
  /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/lib/systemd
  /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/lib/systemd/system
  /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/lib/systemd/system/rauc.service
Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install.
nativesdk-rauc: 9 installed and not shipped files. [installed-vs-shipped]
```
