### PR TITLE
rauc: switch to meson

### DIFF
--- a/recipes-core/rauc/nativesdk-rauc.inc
+++ b/recipes-core/rauc/nativesdk-rauc.inc
@@ -1,6 +1,5 @@
 do_install:append() {
-	rm -rf ${D}${nonarch_base_libdir}
-	rm -rf ${D}${datadir}/dbus-1
+	rm -rf ${D}${datadir}
 }
 
 inherit nativesdk

--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -20,7 +20,7 @@ INITSCRIPT_PARAMS:${PN}-mark-good = "start 99 5 2 . stop 20 0 1 6 ."
 inherit systemd update-rc.d
 
 do_install () {
-	autotools_do_install
+	meson_do_install
 
         # Create rauc config dir
         # Warn if system configuration was not overwritten

--- a/recipes-core/rauc/rauc.inc
+++ b/recipes-core/rauc/rauc.inc
@@ -4,20 +4,20 @@ LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 DEPENDS = "openssl glib-2.0 glib-2.0-native"
 
-inherit autotools pkgconfig gettext
+inherit meson pkgconfig gettext
 
 EXTRA_OECONF += "\
-        --with-systemdunitdir=${systemd_system_unitdir} \
-        --with-dbuspolicydir=${datadir}/dbus-1/system.d \
-        --with-dbussystemservicedir=${datadir}/dbus-1/system-services \
+        -Dsystemdunitdir=${systemd_system_unitdir} \
+        -Ddbuspolicydir=${datadir}/dbus-1/system.d \
+        -Ddbussystemservicedir=${datadir}/dbus-1/system-services \
         "
 
-PACKAGECONFIG[nocreate]  = "--disable-create,--enable-create,"
-PACKAGECONFIG[service] = "--enable-service,--enable-service=no,dbus,${PN}-service"
-PACKAGECONFIG[streaming] = "--enable-streaming,--enable-streaming=no,libnl"
-PACKAGECONFIG[network] = "--enable-network,--enable-network=no,curl"
-PACKAGECONFIG[json]    = "--enable-json,--enable-json=no,json-glib"
-PACKAGECONFIG[gpt]     = "--enable-gpt,--enable-gpt=no,util-linux"
+PACKAGECONFIG[nocreate]  = "-Dcreate=false,-Dcreate=true,"
+PACKAGECONFIG[service] = "-Dservice=true,-Dservice=false,dbus,${PN}-service"
+PACKAGECONFIG[streaming] = "-Dstreaming=true,-Dstreaming=false,libnl"
+PACKAGECONFIG[network] = "-Dnetwork=true,-Dnetwork=false,curl"
+PACKAGECONFIG[json]    = "-Djson=enabled,-Djson=disabled,json-glib"
+PACKAGECONFIG[gpt]     = "-Dgpt=enabled,-Dgpt=disabled,util-linux"
 
 FILES:${PN}-dev += "\
   ${datadir}/dbus-1/interfaces/de.pengutronix.rauc.Installer.xml \


### PR DESCRIPTION
With v1.9, RAUC switched to using meson. Autotools support is kept only for transition phase and might be removed in v1.10.