### PR TITLE
Fixed rauc-mark-good systemd service setup.

### DIFF
--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -72,7 +72,7 @@ FILES:${PN}-mark-good = "${systemd_unitdir}/system/rauc-mark-good.service ${sysc
 
 PACKAGES =+ "${PN}-service"
 SYSTEMD_SERVICE:${PN}-service = "rauc.service"
-SYSTEMD_PACKAGES = "${PN}-service"
+SYSTEMD_PACKAGES += "${PN}-service"
 RDEPENDS:${PN}-service += "dbus"
 
 FILES:${PN}-service = "\


### PR DESCRIPTION
The rauc-service package was overriding the SYSTEMD_PACKAGES variable which resulted in the rauc-mark-good systemd service not receiving it's post install scripts. Now the service should be enabled by default as intended.