### PR TITLE
Add Two Ways of Adding Custom Meta-Data Or Settings to The Manifest

### DIFF
--- a/classes-recipe/bundle.bbclass
+++ b/classes-recipe/bundle.bbclass
@@ -89,6 +89,11 @@
 #   RAUC_META_mydata[release-notes] = "a few notes here"
 #
 #   RAUC_META_foo[bar] = "baz"
+#
+# Adding any sort of additional lines to the manifest can be done with the
+# RAUC_MANIFEST_EXTRA_LINES variable (using '\n' to indicate newlines):
+#
+#   RAUC_MANIFEST_EXTRA_LINES = "[section]\nkey=value\n"
 
 LICENSE ?= "MIT"
 
@@ -326,6 +331,8 @@ def write_manifest(d):
             meta_value = d.getVarFlag('RAUC_META_%s' % meta_section, meta_key)
             manifest.write("%s=%s\n" % (meta_key, meta_value))
         manifest.write("\n");
+
+    manifest.write((d.getVar('RAUC_MANIFEST_EXTRA_LINES') or "").replace(r'\n', '\n'))
 
     manifest.close()
 

--- a/classes-recipe/bundle.bbclass
+++ b/classes-recipe/bundle.bbclass
@@ -79,6 +79,16 @@
 # Enable building casync bundles with
 #
 #   RAUC_CASYNC_BUNDLE = "1"
+#
+# To define custom manifest 'meta' sections, you may use
+# 'RAUC_META_SECTIONS' as follows:
+#
+#   RAUC_META_SECTIONS = "mydata foo"
+#
+#   RAUC_META_mydata[release-type] = "beta"
+#   RAUC_META_mydata[release-notes] = "a few notes here"
+#
+#   RAUC_META_foo[bar] = "baz"
 
 LICENSE ?= "MIT"
 
@@ -309,6 +319,13 @@ def write_manifest(d):
                 raise bb.fatal('Failed to find source %s' % imgsource)
         if not os.path.exists(bundle_imgpath):
             raise bb.fatal("Failed adding image '%s' to bundle: not present in DEPLOY_DIR_IMAGE or WORKDIR" % imgsource)
+
+    for meta_section in (d.getVar('RAUC_META_SECTIONS') or "").split():
+        manifest.write("[meta.%s]\n" % meta_section)
+        for meta_key in d.getVarFlags('RAUC_META_%s' % meta_section):
+            meta_value = d.getVarFlag('RAUC_META_%s' % meta_section, meta_key)
+            manifest.write("%s=%s\n" % (meta_key, meta_value))
+        manifest.write("\n");
 
     manifest.close()
 


### PR DESCRIPTION
With `RAUC_META_SECTIONS` there is a similar approach to how bundles are defined that allows to specify RAUC [meta data sections](https://rauc.readthedocs.io/en/latest/reference.html?highligh=meta#manifest) in the manifest.

With `RAUC_MANIFEST_EXTRA_LINES` any (RAUC-parsable) manifest information can be appended to a manifest.