### PR TITLE
Fixes for building RAUC with meson

### DIFF
--- a/recipes-core/rauc/rauc.inc
+++ b/recipes-core/rauc/rauc.inc
@@ -6,7 +6,7 @@ DEPENDS = "openssl glib-2.0 glib-2.0-native"
 
 inherit meson pkgconfig gettext
 
-EXTRA_OECONF += "\
+EXTRA_OEMESON += "\
         -Dsystemdunitdir=${systemd_system_unitdir} \
         -Ddbuspolicydir=${datadir}/dbus-1/system.d \
         -Ddbussystemservicedir=${datadir}/dbus-1/system-services \

--- a/recipes-core/rauc/rauc.inc
+++ b/recipes-core/rauc/rauc.inc
@@ -7,6 +7,7 @@ DEPENDS = "openssl glib-2.0 glib-2.0-native"
 inherit meson pkgconfig gettext
 
 EXTRA_OEMESON += "\
+        -Dtests=false \
         -Dsystemdunitdir=${systemd_system_unitdir} \
         -Ddbuspolicydir=${datadir}/dbus-1/system.d \
         -Ddbussystemservicedir=${datadir}/dbus-1/system-services \


### PR DESCRIPTION
* Fixes using EXTRA_OECONF where EXTRA_OEMESON should be used
* disables building tests (avoids potential build issues)