### PR TITLE
classes-recipe: bundle: add ".rootfs" to default image search path

### DIFF
--- a/classes-recipe/bundle.bbclass
+++ b/classes-recipe/bundle.bbclass
@@ -254,7 +254,7 @@ def write_manifest(d):
             if slotflags and 'file' in slotflags:
                 imgsource = d.getVarFlag('RAUC_SLOT_%s' % slot, 'file')
             else:
-                imgsource = "%s-%s.%s" % (d.getVar('RAUC_SLOT_%s' % slot), machine, img_fstype)
+                imgsource = "%s-%s.rootfs.%s" % (d.getVar('RAUC_SLOT_%s' % slot), machine, img_fstype)
             imgname = imgsource
         elif imgtype == 'kernel':
             # TODO: Add image type support


### PR DESCRIPTION
Since oe-core commit openembedded/openembedded-core@26d97acc71379ab6702fa54a23b6542a3f51779c ("image-artifact-names: include ${IMAGE_NAME_SUFFIX} directly in both ${IMAGE_NAME} and ${IMAGE_LINK_NAME}"), now also image symlinks contain the '.rootfs' suffix that images already had.

Adapt to this change by adding ".rootfs" to the default search path for rootfs images (i.e. their symlinks).