### PR TITLE
bundle: core-bundle-minimal: use verity format

### DIFF
--- a/recipes-core/bundles/core-bundle-minimal.bb
+++ b/recipes-core/bundles/core-bundle-minimal.bb
@@ -15,6 +15,8 @@
 
 inherit bundle
 
+RAUC_BUNDLE_FORMAT = "verity"
+
 RAUC_BUNDLE_COMPATIBLE ?= "Demo Board"
 
 RAUC_BUNDLE_SLOTS ?= "rootfs"


### PR DESCRIPTION
The 'plain' format should not be used anymore but the 'verity' format still requires explicit selection.
So use the appropriate format for this example.

This will also silence the warning generated for this case:

>  WARNING: core-bundle-minimal-1.0-r0 do_configure: No RAUC_BUNDLE_FORMAT set. This will default to using legacy 'plain' format.
> If you are unsure, set RAUC_BUNDLE_FORMAT = "verity" for new projects.
> Refer to https://rauc.readthedocs.io/en/latest/reference.html#sec-ref-formats for more information about RAUC bundle formats.