### PR TITLE
rauc: explictly set dbusinterfacesdir

### DIFF
--- a/recipes-core/rauc/rauc.inc
+++ b/recipes-core/rauc/rauc.inc
@@ -11,6 +11,7 @@ EXTRA_OEMESON += "\
         -Dsystemdunitdir=${systemd_system_unitdir} \
         -Ddbuspolicydir=${datadir}/dbus-1/system.d \
         -Ddbussystemservicedir=${datadir}/dbus-1/system-services \
+        -Ddbusinterfacesdir=${datadir}/dbus-1/interfaces \
         "
 
 PACKAGECONFIG[nocreate]  = "-Dcreate=false,-Dcreate=true,"


### PR DESCRIPTION
As the `dbusinterfacesdir` variable was not explicitly set and the default was evaluating to `/etc/dbus-1/system.d`, `bitbake` was not able to properly add file `de.pengutronix.rauc.Installer.xml` in `rauc-dev` package.

See also rauc/rauc#1184.