### PR TITLE
Remove Redundant Extension of SRC_URI from README.rst and system.conf

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,6 @@ you have to follow at least the following steps:
    update file, please refer to the RAUC user documentation [1]_::
 
      FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
-     SRC_URI:append := " file://system.conf"
 
 3. Create a bundle recipe for your device by adding a recipe
    that inherits the `bundle` class and adds all desired

--- a/recipes-core/rauc/files/system.conf
+++ b/recipes-core/rauc/files/system.conf
@@ -8,8 +8,6 @@
 ## 
 ##   FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 ##   
-##   SRC_URI:append := " file://system.conf"
-##
 ## ---
 ##
 # [system]


### PR DESCRIPTION
An entry for "system.conf" has already been added via rauc-target.inc.