### PR TITLE
rauc: register systemd service only if configured

### DIFF
--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -71,7 +71,7 @@ RRECOMMENDS:${PN}:append = " ${PN}-mark-good"
 FILES:${PN}-mark-good = "${systemd_unitdir}/system/rauc-mark-good.service ${sysconfdir}/init.d/rauc-mark-good"
 
 PACKAGES =+ "${PN}-service"
-SYSTEMD_SERVICE:${PN}-service = "rauc.service"
+SYSTEMD_SERVICE:${PN}-service = "${@bb.utils.contains('PACKAGECONFIG', 'service', 'rauc.service', '', d)}"
 SYSTEMD_PACKAGES += "${PN}-service"
 RDEPENDS:${PN}-service += "dbus"
 


### PR DESCRIPTION
When the `PACKAGECONFIG` did not include `"service"`, bitbake was failing with

    ERROR: rauc-1.10-r0 do_package: Didn't find service unit 'rauc.service', specified in SYSTEMD_SERVICE:rauc-service.

Fixed this by setting the `SYSTEMD_SERVICE` variable only when the corresponding service flag in the `PACKAGECONFIG` variable is also set.

This should fix #279 