### PR TITLE
dt-utils: update to 2023.11.0

### DIFF
--- a/recipes-bsp/dt-utils/dt-utils_2023.08.0.bb
+++ b/recipes-bsp/dt-utils/dt-utils_2023.08.0.bb
@@ -1,3 +1,0 @@
-require dt-utils.inc
-
-SRC_URI[sha256sum] = "15cda6fdbaaf08711e55b49db4479f3af48660b812d8d587ec9b3fffaa13a0f7"

--- a/recipes-bsp/dt-utils/dt-utils_2023.11.0.bb
+++ b/recipes-bsp/dt-utils/dt-utils_2023.11.0.bb
@@ -1,0 +1,3 @@
+require dt-utils.inc
+
+SRC_URI[sha256sum] = "d224d941c076c143f43d59cd7c6e1c522926064a31ac34a67720632ddecb6b53"


### PR DESCRIPTION
This release fixes an issue when using `barebox-state` on systems with a barebox state partition on the eMMC user partition. Without this patch barebox-state searches for the state partition on one of the eMMC boot (hardware) partitions.

This fixes 6c5faed, which introduced the `dt-utils` version with the broken `barebox-state`. Older `dt-utils` versions are not affected.