### PR TITLE
remove PR from recipes

### DIFF
--- a/recipes-bsp/dt-utils/dt-utils.inc
+++ b/recipes-bsp/dt-utils/dt-utils.inc
@@ -4,7 +4,6 @@ SECTION = "base"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=18d902a0242c37a4604224b47d02f802"
 DEPENDS = "udev"
-PR = "r0"
 
 SRC_URI = "http://www.pengutronix.de/software/dt-utils/download/${BPN}-${PV}.tar.xz"
 

--- a/recipes-core/rauc/rauc-git.inc
+++ b/recipes-core/rauc/rauc-git.inc
@@ -1,5 +1,3 @@
-PR = "r0"
-
 SRC_URI = " \ 
   git://github.com/rauc/rauc.git;protocol=https;branch=master \
   "


### PR DESCRIPTION
oe-core recently removed PR values of recipes tree-wide, e.g. in d4c346e8 ("recipes: Drop remaining PR values from recipes").

Just do the same here, especially since the value was never changed from "r0" which is the default from bitbake.conf anyway.