### PR TITLE
.github: workflows: meta-rauc: meta-networking depends on meta-python

### DIFF
--- a/.github/workflows/meta-rauc.yml
+++ b/.github/workflows/meta-rauc.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           source poky/oe-init-build-env build
           bitbake-layers add-layer ../meta-openembedded/meta-oe
+          bitbake-layers add-layer ../meta-openembedded/meta-python
           bitbake-layers add-layer ../meta-openembedded/meta-networking
           bitbake-layers add-layer ../meta-openembedded/meta-filesystems
           bitbake casync casync-native


### PR DESCRIPTION
Since meta-openembedded commit ab7c469b ("meta-networking: Express dependency on meta-python"), meta-networking depends on meta-python. Thus add meta-python before adding meta-networking.