### PR TITLE
rauc: rauc-mark-good: disable implicit dependencies

### DIFF
--- a/recipes-core/rauc/files/rauc-mark-good.service
+++ b/recipes-core/rauc/files/rauc-mark-good.service
@@ -4,6 +4,7 @@ ConditionKernelCommandLine=|bootchooser.active
 ConditionKernelCommandLine=|rauc.slot
 After=boot-complete.target
 Requires=boot-complete.target
+DefaultDependencies=no
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Having implicit dependencies enabled would lead to ordering cycles when enabling 'boot assessment', through
systemd-boot-check-no-failures [1], which is a service that forces the multi-user.target to be reached before the boot-complete.target.

The ordering cycle in this case would be:
boot-complete -requires-> systemd-boot-check-no-failures systemd-boot-check-no-failures -after-> multi-user rauc-mark-good -after-> boot-complete
boot-complete -after-> multi-user
multi-user -after-> rauc-mark-good

![circle](https://github.com/rauc/meta-rauc/assets/108275545/b778a63e-8768-4165-8970-9d4df42eca4e)

Which systemd would break by simply not running rauc-mark-good.

The solution is to disable implicit dependencies that would otherwise add an 'After=rauc-mark-good.service' to the multi-user.target via the [Install] section.

Link: https://www.freedesktop.org/software/systemd/man/latest/systemd-boot-check-no-failures.html