### PR TITLE
layer.conf: switch to scarthgap series

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,7 +17,7 @@ LAYERRECOMMENDS_rauc = "meta-python"
 # meta-filesystems is needed to build cascync with fuse support (the default)
 LAYERRECOMMENDS_rauc += "meta-filesystems"
 
-LAYERSERIES_COMPAT_rauc = "nanbield"
+LAYERSERIES_COMPAT_rauc = "nanbield scarthgap"
 
 # Sanity check for meta-rauc layer.
 # Setting SKIP_META_RAUC_FEATURE_CHECK to "1" would skip the bbappend files check.


### PR DESCRIPTION
Since oe-core switched to `scarthgap` release series only (i.e. removed `nanbield` compatiblity), we have to update our `layer.conf` file.