### PR TITLE
bundle.bbclass: use IMAGE_MACHINE_SUFFIX instead of hard-coded '-${MACHINE}'

### DIFF
--- a/classes-recipe/bundle.bbclass
+++ b/classes-recipe/bundle.bbclass
@@ -253,7 +253,7 @@ def write_manifest(d):
         img_fstype = slotflags.get('fstype', d.getVar('RAUC_IMAGE_FSTYPE'))
 
         if imgtype == 'image':
-            fallback = "%s-%s%s.%s" % (d.getVar('RAUC_SLOT_%s' % slot), machine, d.getVar('IMAGE_NAME_SUFFIX'), img_fstype)
+            fallback = "%s%s%s.%s" % (d.getVar('RAUC_SLOT_%s' % slot), d.getVar('IMAGE_MACHINE_SUFFIX'), d.getVar('IMAGE_NAME_SUFFIX'), img_fstype)
             imgname = imgsource = slotflags.get('file', fallback)
         elif imgtype == 'kernel':
             # TODO: Add image type support


### PR DESCRIPTION
Similar to #299, when changing the default IMAGE_MACHINE_SUFFIX the bundle build fails (error in do_configure()).
The fix is identical to #300.