### PR TITLE
README.rst: remove left-over reference to tmp/deploy/tools

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,8 +68,6 @@ calling ``rauc info`` on your built bundle, simply run::
   bitbake rauc-native -caddto_recipe_sysroot
   oe-run-native rauc-native rauc info --keyring=/path/to/keyring.pem tmp/deploy/images/<machine>/<bundle-name>.raucb
 
-This will place the rauc binary at ``tmp/deploy/tools/rauc``.
-
 If you need to execute the ``casync`` host tool manually, you can do this by running::
 
   bitbake casync-native -caddto_recipe_sysroot


### PR DESCRIPTION
Support for placing the native rauc tool under the deploy directory was removed a while ago in favor of the better oe-run-native approach (which uses the proper native sysroot, too).
Somehow this misleading comment survived the README update then.

Fixes: 79554c6 ("rauc-native: do not deploy tool anymore")