### PR TITLE
Follow WORKDIR -> UNPACKDIR transition

### DIFF
--- a/classes-recipe/bundle.bbclass
+++ b/classes-recipe/bundle.bbclass
@@ -51,7 +51,7 @@
 #
 # To add additional artifacts to the bundle you can use RAUC_BUNDLE_EXTRA_FILES
 # and RAUC_BUNDLE_EXTRA_DEPENDS.
-# For files from the WORKDIR (fetched using SRC_URI) you can write:
+# For files from the UNPACKDIR (fetched using SRC_URI) you can write:
 #
 #   SRC_URI += "file://myfile"
 #   RAUC_BUNDLE_EXTRA_FILES += "myfile"
@@ -130,7 +130,7 @@ RAUC_BUNDLE_BUILD[doc] = "Specifies the bundle build stamp. See RAUC documentati
 RAUC_BUNDLE_SLOTS[doc] = "Space-separated list of slot classes to include in bundle (manifest)"
 RAUC_BUNDLE_HOOKS[doc] = "Allows to specify an additional hook executable and bundle hooks (via varflags '[file'] and ['hooks'])"
 
-RAUC_BUNDLE_EXTRA_FILES[doc] = "Specifies list of additional files to add to bundle. Files must either be located in WORKDIR (added by SRC_URI) or DEPLOY_DIR_IMAGE (assured by RAUC_BUNDLE_EXTRA_DEPENDS)"
+RAUC_BUNDLE_EXTRA_FILES[doc] = "Specifies list of additional files to add to bundle. Files must either be located in UNPACKDIR (added by SRC_URI) or DEPLOY_DIR_IMAGE (assured by RAUC_BUNDLE_EXTRA_DEPENDS)"
 RAUC_BUNDLE_EXTRA_DEPENDS[doc] = "Specifies list of recipes that create artifacts in DEPLOY_DIR_IMAGE. For recipes not depending on do_deploy task also <recipename>:do_<taskname> notation is supported"
 
 RAUC_CASYNC_BUNDLE ??= "0"
@@ -177,7 +177,8 @@ python __anonymous() {
         bb.note('adding extra dependency %s:%s' % (imagewithdep[0],  deptask))
 }
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 B = "${WORKDIR}/build"
 BUNDLE_DIR = "${S}/bundle"
 
@@ -308,13 +309,13 @@ def write_manifest(d):
             else:
                 shutil.copy(searchpath, bundle_imgpath)
         else:
-            searchpath = d.expand("${WORKDIR}/%s") % imgsource
+            searchpath = d.expand("${UNPACKDIR}/%s") % imgsource
             if os.path.isfile(searchpath):
                 shutil.copy(searchpath, bundle_imgpath)
             else:
                 raise bb.fatal('Failed to find source %s' % imgsource)
         if not os.path.exists(bundle_imgpath):
-            raise bb.fatal("Failed adding image '%s' to bundle: not present in DEPLOY_DIR_IMAGE or WORKDIR" % imgsource)
+            raise bb.fatal("Failed adding image '%s' to bundle: not present in DEPLOY_DIR_IMAGE or UNPACKDIR" % imgsource)
 
     for meta_section in (d.getVar('RAUC_META_SECTIONS') or "").split():
         manifest.write("[meta.%s]\n" % meta_section)
@@ -335,7 +336,7 @@ def try_searchpath(file, d):
         bb.note("adding extra directory from deploy dir to bundle dir: '%s'" % file)
         return searchpath
 
-    searchpath = d.expand("${WORKDIR}/%s") % file
+    searchpath = d.expand("${UNPACKDIR}/%s") % file
     if os.path.isfile(searchpath):
         bb.note("adding extra file from workdir to bundle dir: '%s'" % file)
         return searchpath
@@ -357,12 +358,12 @@ python do_configure() {
     hooksflags = d.getVarFlags('RAUC_BUNDLE_HOOKS', expand=hooks_varflags) or {}
     if 'file' in hooksflags:
         hf = hooksflags.get('file')
-        if not os.path.exists(d.expand("${WORKDIR}/%s" % hf)):
-            bb.error("hook file '%s' does not exist in WORKDIR" % hf)
+        if not os.path.exists(d.expand("${UNPACKDIR}/%s" % hf)):
+            bb.error("hook file '%s' does not exist in UNPACKDIR" % hf)
             return
         dsthook = d.expand("${BUNDLE_DIR}/%s" % hf)
         bb.note("adding hook file to bundle dir: '%s'" % hf)
-        shutil.copy(d.expand("${WORKDIR}/%s" % hf), dsthook)
+        shutil.copy(d.expand("${UNPACKDIR}/%s" % hf), dsthook)
         st = os.stat(dsthook)
         os.chmod(dsthook, st.st_mode | stat.S_IEXEC)
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,7 +17,7 @@ LAYERRECOMMENDS_rauc = "meta-python"
 # meta-filesystems is needed to build cascync with fuse support (the default)
 LAYERRECOMMENDS_rauc += "meta-filesystems"
 
-LAYERSERIES_COMPAT_rauc = "nanbield scarthgap"
+LAYERSERIES_COMPAT_rauc = "styhead"
 
 # Sanity check for meta-rauc layer.
 # Setting SKIP_META_RAUC_FEATURE_CHECK to "1" would skip the bbappend files check.

--- a/recipes-core/rauc/rauc-conf.bb
+++ b/recipes-core/rauc/rauc-conf.bb
@@ -15,19 +15,22 @@ SRC_URI = " \
   ${RAUC_KEYRING_URI} \
   "
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 do_install () {
         # Create rauc config dir
         # Warn if system configuration was not overwritten
-        if ! grep -q "^[^#]" ${WORKDIR}/system.conf; then
+        if ! grep -q "^[^#]" ${UNPACKDIR}/system.conf; then
                 bbwarn "Please overwrite example system.conf with a project specific one!"
         fi
         install -d ${D}${sysconfdir}/rauc
-        install -m 0644 ${WORKDIR}/system.conf ${D}${sysconfdir}/rauc/
+        install -m 0644 ${UNPACKDIR}/system.conf ${D}${sysconfdir}/rauc/
 
         # Warn if CA file was not overwritten
-        if ! grep -q "^[^#]" ${WORKDIR}/${RAUC_KEYRING_FILE}; then
+        if ! grep -q "^[^#]" ${UNPACKDIR}/${RAUC_KEYRING_FILE}; then
                 bbwarn "Please overwrite example ca.cert.pem with a project specific one, or set the RAUC_KEYRING_FILE variable with your file!"
         fi
         install -d ${D}${sysconfdir}/rauc
-        install -m 0644 ${WORKDIR}/${RAUC_KEYRING_FILE} ${D}${sysconfdir}/rauc/
+        install -m 0644 ${UNPACKDIR}/${RAUC_KEYRING_FILE} ${D}${sysconfdir}/rauc/
 }

--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -22,11 +22,11 @@ do_install () {
 	meson_do_install
 
         install -d ${D}${systemd_unitdir}/system/
-        install -m 0644 ${WORKDIR}/rauc-mark-good.service ${D}${systemd_unitdir}/system/
+        install -m 0644 ${UNPACKDIR}/rauc-mark-good.service ${D}${systemd_unitdir}/system/
         sed -i -e 's!@BINDIR@!${bindir}!g' ${D}${systemd_unitdir}/system/*.service
 
         install -d "${D}${sysconfdir}/init.d"
-        install -m 755 "${WORKDIR}/rauc-mark-good.init" "${D}${sysconfdir}/init.d/rauc-mark-good"
+        install -m 755 "${UNPACKDIR}/rauc-mark-good.init" "${D}${sysconfdir}/init.d/rauc-mark-good"
 }
 
 PACKAGES =+ "${PN}-mark-good"

--- a/recipes-support/rauc-hawkbit/rauc-hawkbit_git.bb
+++ b/recipes-support/rauc-hawkbit/rauc-hawkbit_git.bb
@@ -28,7 +28,7 @@ do_install:append() {
 	install -d ${D}${sysconfdir}/${BPN}/
 	install -m 0644 ${S}/rauc_hawkbit/config.cfg ${D}${sysconfdir}/${BPN}/config.cfg
 	install -d ${D}${systemd_unitdir}/system/
-	install -m 0644 ${WORKDIR}/rauc-hawkbit.service ${D}${systemd_unitdir}/system/
+	install -m 0644 ${UNPACKDIR}/rauc-hawkbit.service ${D}${systemd_unitdir}/system/
 	sed -i -e 's!@BINDIR@!${bindir}!g' -e 's!@SYSCONFDIR@!${sysconfdir}!g' \
 		${D}${systemd_unitdir}/system/rauc-hawkbit.service
 }


### PR DESCRIPTION
This adapts to the oe-core rework to enforce a separate directory for unpacking local sources (`UNPACKDIR`) instead of polluting `WORKDIR` directly.

Follows the preliminary guidelines from:
https://lists.openembedded.org/g/openembedded-architecture/message/2007

For this, we need to break compatibility with all releases before `master`.