### PR TITLE
bundle.bbclass: do not generate SSTATE artifacts

### DIFF
--- a/classes-recipe/bundle.bbclass
+++ b/classes-recipe/bundle.bbclass
@@ -454,6 +454,8 @@ addtask bundle after do_configure
 
 inherit deploy
 
+SSTATE_SKIP_CREATION:task-deploy = '1'
+
 do_deploy() {
 	install -d ${DEPLOYDIR}
 	install -m 0644 ${B}/bundle.raucb ${DEPLOYDIR}/${BUNDLE_NAME}${BUNDLE_EXTENSION}


### PR DESCRIPTION
The artifacts created are quite large and keeping multiple of them will consume a notable amount of disk space while the expected speed-up is minimal.
(For the same reasons, the image class does not generate SSTATE artifacts).

Having SSTATE artifacts for bundles enabled can also lead to unexpected/unwanted behavior if a rootfs image recipe was rebuild and the binary output (file system image) changed but did not make it into the final bundle.
This becomes a major problem, e.g. in the context of verified boot.