### PR TITLE
README: rauc-conf needs to be appended now instead of rauc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,18 @@ Please submit patches via GitHub pull request on https://github.com/rauc/meta-ra
 
 Maintainer: Enrico Joerns <ejo@pengutronix.de>
 
+Migration Notes
+===============
+
+Since **scarthgap**, the platform configuration (system.conf, keyring, etc.) was
+moved to a separate ``rauc-conf.bb`` recipe to allow building the rauc package
+with ``TUNE_PKGARCH`` and have a clearer separation between the binary and the
+configuration.
+
+Thus when updating to scarthgap or newer, make sure to move all
+configuration-specific adaptions from your ``rauc_%.bbappend`` to a
+``rauc-conf.bbappend`` file.
+
 
 I. Adding the rauc Layer to Your Build
 ======================================
@@ -85,7 +97,7 @@ you have to follow at least the following steps:
 
      DISTRO_FEATURES += "rauc"
 
-2. Add a ``rauc_%.bbappend`` in your device-specific (BSP) layer
+2. Add a ``rauc-conf.bbappend`` in your device-specific (BSP) layer
    that installs your RAUC system configuration file under
    ``/etc/rauc/system.conf``. For information on how to write the RAUC
    update file, please refer to the RAUC user documentation [1]_::

--- a/scripts/README
+++ b/scripts/README
@@ -17,8 +17,8 @@ To use them in your BSP in order to sign and verify bundles, you have to:
 
    Copy the keyring file `dev/ca.cert.pem` into your projects meta layer under
    `recipes-core/rauc/files` and add a simple rauc .bbappend file
-   `recipes-core/rauc/rauc_%.bbappend` that adds the keyring file to the rauc
-   package search path:
+   `recipes-core/rauc/rauc-conf.bbappend` that adds the keyring file to the rauc
+   config package search path:
 
      FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 


### PR DESCRIPTION
With d51bab8f (rauc: split package into 'rauc' for binary and 'rauc-conf' for configuration), users need to append rauc-conf instead of rauc when providing their device-specific configuration.

This was not reflected by the docs yet.

Also add an explicit migration note early in the README.rst.