### PR TITLE
rauc-git: update to latest SRCREV

### DIFF
--- a/recipes-core/rauc/rauc-git.inc
+++ b/recipes-core/rauc/rauc-git.inc
@@ -2,10 +2,10 @@ SRC_URI = " \
   git://github.com/rauc/rauc.git;protocol=https;branch=master \
   "
 
-PV = "1.10.1+git${SRCPV}"
+PV = "1.11.3+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-SRCREV = "69a95ede643929164f0d044e154c928a855c71a7"
+SRCREV = "47790fd2f0525a121792bc7fa28c1596c1b99fef"
 
 RAUC_USE_DEVEL_VERSION[doc] = "Global switch to enable RAUC development (git) version."
 RAUC_USE_DEVEL_VERSION ??= "-1"

--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -63,6 +63,7 @@ FILES:${PN}-service = "\
   ${systemd_unitdir}/system/rauc.service \
   ${datadir}/dbus-1/system.d/de.pengutronix.rauc.conf \
   ${datadir}/dbus-1/system-services/de.pengutronix.rauc.service \
+  ${nonarch_libdir}/systemd/catalog \
   "
 
 PACKAGECONFIG ??= "service network streaming json nocreate gpt"


### PR DESCRIPTION
With the latest master branch state, RAUC gained support for installing a systemd catalog file.
Add the catalog path to the common `FILES:${PN}-service` for `rauc-target.inc` sine it will not have an impact when using it with a release not containing the catalog file.