### PR TITLE
rauc-git: update to latest SRCREV

### DIFF
--- a/recipes-core/rauc/rauc-git.inc
+++ b/recipes-core/rauc/rauc-git.inc
@@ -5,7 +5,7 @@ SRC_URI = " \
 PV = "1.11.3+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-SRCREV = "47790fd2f0525a121792bc7fa28c1596c1b99fef"
+SRCREV = "cf4d63a46c6b0a7a5cba3b039d146bbd6fd59665"
 
 RAUC_USE_DEVEL_VERSION[doc] = "Global switch to enable RAUC development (git) version."
 RAUC_USE_DEVEL_VERSION ??= "-1"


### PR DESCRIPTION
This advances the git revision by [one commit](https://github.com/rauc/rauc/commit/e8080a2e3078be4c12057b26ae1d6b7c634348f9) (plus one merge commit). See rauc/rauc#1456. 
Said commit fixes a SIGSEGV that happens when logging via journald because of a NULL field in the logged data.