### PR TITLE
curl: enable PACKAGECONFIG for HTTP/2 (nghttp2) on the target

### DIFF
--- a/recipes-support/curl/curl_%.bbappend
+++ b/recipes-support/curl/curl_%.bbappend
@@ -1,0 +1,1 @@
+require ${@bb.utils.contains('DISTRO_FEATURES', 'rauc', '${BPN}_rauc.inc', '', d)}

--- a/recipes-support/curl/curl_rauc.inc
+++ b/recipes-support/curl/curl_rauc.inc
@@ -1,0 +1,5 @@
+# HTTP/2 allows having multiple parallel (range-) requests in flight on the
+# same connection without requiring multiple TCP and TLS handshakes.
+# This speeds up adaptive updates a lot, since they work by making many
+# range-requests for parts of the update bundle.
+PACKAGECONFIG:append:class-target = " nghttp2"


### PR DESCRIPTION
Without HTTP/2 support, streaming installation is significantly slower.