### PR TITLE
bundle.bbclass: fix variable expansion of RAUC_META_* varflags

### DIFF
--- a/classes-recipe/bundle.bbclass
+++ b/classes-recipe/bundle.bbclass
@@ -315,7 +315,8 @@ def write_manifest(d):
 
     for meta_section in (d.getVar('RAUC_META_SECTIONS') or "").split():
         manifest.write("[meta.%s]\n" % meta_section)
-        for meta_key, meta_value in d.getVarFlags('RAUC_META_%s' % meta_section).items():
+        for meta_key in d.getVarFlags('RAUC_META_%s' % meta_section):
+            meta_value = d.getVarFlag('RAUC_META_%s' % meta_section, meta_key)
             manifest.write("%s=%s\n" % (meta_key, meta_value))
         manifest.write("\n");
 


### PR DESCRIPTION
variables assigned to `RAUC_META_<section>[varflag]` are not expanded anymore.

This is caused by `getVarFlags` not expanding variables by default, revert to using `getVarFlag` which does expand variables by default.

fix #335

partially revert changes introduced in ffba61f2f79ec03395629d8713a59226b0158d5f