### PR TITLE
bundle.bbclass: support manifest generation for artifacts

### DIFF
--- a/classes-recipe/bundle.bbclass
+++ b/classes-recipe/bundle.bbclass
@@ -406,7 +406,7 @@ CASYNC_BUNDLE_LINK_NAME ??= "${CASYNC_BUNDLE_BASENAME}-${MACHINE}"
 CASYNC_BUNDLE_EXTENSION ??= "${BUNDLE_EXTENSION}"
 CASYNC_BUNDLE_EXTENSION[doc] = "Specifies desired custom filename extension of generated RAUC casync bundle."
 
-do_bundle() {
+fakeroot do_bundle() {
 	if [ -z "${RAUC_KEY_FILE}" ]; then
 		bbfatal "'RAUC_KEY_FILE' not set. Please set to a valid key file location."
 	fi
@@ -428,13 +428,7 @@ do_bundle() {
 			bbfatal "'RAUC_KEYRING_FILE' not set. Please set a valid keyring file location."
 		fi
 
-		# There is no package providing a binary named "fakeroot" but instead a
-		# replacement named "pseudo". But casync requires fakeroot to be
-		# installed, thus make a symlink.
-		if ! [ -x "$(command -v fakeroot)" ]; then
-			ln -sf ${STAGING_BINDIR_NATIVE}/pseudo ${STAGING_BINDIR_NATIVE}/fakeroot
-		fi
-		PSEUDO_PREFIX=${STAGING_DIR_NATIVE}/${prefix_native} PSEUDO_DISABLED=0 ${STAGING_BINDIR_NATIVE}/rauc convert \
+		${STAGING_BINDIR_NATIVE}/rauc convert \
 			--debug \
 			--trust-environment \
 			--cert=${RAUC_CERT_FILE} \

--- a/classes-recipe/bundle.bbclass
+++ b/classes-recipe/bundle.bbclass
@@ -40,6 +40,12 @@
 #   RAUC_SLOT_rootfs ?= "core-image-minimal"
 #   RAUC_SLOT_rootfs[rename] ?= "rootfs.ext4"
 #
+# To generate an artifact image, use <repo>/<artifact> as the image name:
+#   RAUC_BUNDLE_SLOTS += "containers/test"
+#   RAUC_SLOT_containers/test ?= "container-test-image"
+#   RAUC_SLOT_containers/test[fstype] = "tar.gz"
+#   RAUC_SLOT_containers/test[convert] = "tar-extract;composefs"
+#
 # To prepend an offset to a bootloader image, set the following parameter in bytes.
 # Optionally you can use units allowed by 'dd' e.g. 'K','kB','MB'.
 # If the offset is negative, bytes will not be added, but removed.
@@ -135,7 +141,7 @@ RAUC_CASYNC_BUNDLE ??= "0"
 RAUC_BUNDLE_FORMAT ??= ""
 RAUC_BUNDLE_FORMAT[doc] = "Specifies the bundle format to be used (plain/verity)."
 
-RAUC_VARFLAGS_SLOTS = "name type fstype file hooks adaptive rename offset depends"
+RAUC_VARFLAGS_SLOTS = "name type fstype file hooks adaptive rename offset depends convert"
 RAUC_VARFLAGS_HOOKS = "file hooks"
 
 # Create dependency list from images
@@ -292,6 +298,8 @@ def write_manifest(d):
             manifest.write("hooks=%s\n" % slotflags.get('hooks'))
         if 'adaptive' in slotflags:
             manifest.write("adaptive=%s\n" % slotflags.get('adaptive'))
+        if 'convert' in slotflags:
+            manifest.write("convert=%s\n" % slotflags.get('convert'))
         manifest.write("\n")
 
         bundle_imgpath = "%s/%s" % (bundle_path, imgname)


### PR DESCRIPTION
This is useful only in combination with the upcoming support for artifacts, but shouldn't hurt the standard case for now.