### PR TITLE
rauc: update kirkstone to v1.12

### DIFF
--- a/recipes-core/rauc/nativesdk-rauc_1.12.bb
+++ b/recipes-core/rauc/nativesdk-rauc_1.12.bb
@@ -1,3 +1,3 @@
 require rauc.inc
-require rauc-1.11.3.inc
+require rauc-1.12.inc
 require nativesdk-rauc.inc

--- a/recipes-core/rauc/rauc-1.12.inc
+++ b/recipes-core/rauc/rauc-1.12.inc
@@ -1,5 +1,5 @@
 SRC_URI = "https://github.com/rauc/rauc/releases/download/v${PV}/rauc-${PV}.tar.xz"
 
-SRC_URI[sha256sum] = "ef82ee452939c03a24fd40649afa96497f3cec965994e6c9c0d94239b640bc10"
+SRC_URI[sha256sum] = "96681e119af8b6b9bb30e856a831e5a5b3292e9a5959d26ffa274b5135bc5031"
 
 UPSTREAM_CHECK_URI = "https://github.com/${BPN}/${BPN}/releases"

--- a/recipes-core/rauc/rauc-git.inc
+++ b/recipes-core/rauc/rauc-git.inc
@@ -4,7 +4,7 @@ SRC_URI = " \
   git://github.com/rauc/rauc.git;protocol=https;branch=master \
   "
 
-PV = "1.10.1+git${SRCPV}"
+PV = "1.12+git${SRCPV}"
 S = "${WORKDIR}/git"
 
 SRCREV = "734bf8937ab154b5edf38bf82c18ca0d7ff1a631"

--- a/recipes-core/rauc/rauc-native_1.12.bb
+++ b/recipes-core/rauc/rauc-native_1.12.bb
@@ -1,3 +1,3 @@
 require rauc.inc
 require rauc-native.inc
-require rauc-1.11.3.inc
+require rauc-1.12.inc

--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -79,6 +79,7 @@ FILES:${PN}-service = "\
   ${systemd_unitdir}/system/rauc.service \
   ${datadir}/dbus-1/system.d/de.pengutronix.rauc.conf \
   ${datadir}/dbus-1/system-services/de.pengutronix.rauc.service \
+  ${nonarch_libdir}/systemd/catalog \
   "
 
 PACKAGECONFIG ??= "service network streaming json nocreate gpt"

--- a/recipes-core/rauc/rauc_1.12.bb
+++ b/recipes-core/rauc/rauc_1.12.bb
@@ -1,3 +1,3 @@
 require rauc.inc
 require rauc-target.inc
-require rauc-1.11.3.inc
+require rauc-1.12.inc


### PR DESCRIPTION
This commit was created by cherry picking commit 02dcc8e5dee786e165d26c816e819b728730e4cf and squashing the last hunk of commit cb01111f0e93e1bb197054ae92a909bb9a4f836f.