### PR TITLE
classes: bundle: use getVarFlag instead of .get

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -231,17 +231,17 @@ def write_manifest(d):
     for slot in (d.getVar('RAUC_BUNDLE_SLOTS') or "").split():
         slotflags = d.getVarFlags('RAUC_SLOT_%s' % slot)
         if slotflags and 'name' in slotflags:
-            slotname = slotflags.get('name')
+            slotname = d.getVarFlag('RAUC_SLOT_%s' % slot, 'name')
         else:
             slotname = slot
         manifest.write('[image.%s]\n' % slotname)
         if slotflags and 'type' in slotflags:
-            imgtype = slotflags.get('type')
+            imgtype = d.getVarFlag('RAUC_SLOT_%s' % slot, 'type')
         else:
             imgtype = 'image'
 
         if slotflags and 'fstype' in slotflags:
-            img_fstype = slotflags.get('fstype')
+            img_fstype = d.getVarFlag('RAUC_SLOT_%s' % slot, 'fstype')
         else:
             img_fstype = d.getVar('RAUC_IMAGE_FSTYPE')
 


### PR DESCRIPTION
Make use of .getVarFlag instead of the simple .get to allow bitbake level variable expansion.

This is useful especially when using https://rauc.readthedocs.io/en/latest/advanced.html#sec-variants with the device-tree compatible constructed from another variable in e.g. the machine config

for consistencies sake the other/close `slotfllag.get` calls where also replaced

---
Example, from a bundle recipe:
```
RAUC_SLOT_bootloader = "barebox-foo"
RAUC_SLOT_bootloader[name] = "bootloader.foo,product-Rev${MACHINE_REVISION}"                                      
RAUC_SLOT_bootloader[type] = "boot"
...
```

---
Sidenote: i currently don't have a full build+config setup for something newer than `kirkstone`... but the changes should port easily? 