### PR TITLE
use pengutronix-hosted runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,9 @@ jobs:
         with:
           path: meta-rauc
       - name: Clone poky
-        run: git clone -b master git://git.yoctoproject.org/poky
+        run: git clone --shared --reference-if-able /srv/shared-git/poky.git -b master https://github.com/yoctoproject/poky.git
       - name: Clone meta-openembedded
-        run: git clone -b master https://github.com/openembedded/meta-openembedded.git
+        run: git clone --shared --reference-if-able /srv/shared-git/meta-openembedded.git -b master https://github.com/openembedded/meta-openembedded.git
       - name: Initialize build directory
         run: |
           source poky/oe-init-build-env build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Install required packages
         run: |
-          sudo apt-get install diffstat
+          sudo apt-get -q -y --no-install-recommends install diffstat
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           sudo apt-get install diffstat
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: meta-rauc
       - name: Clone poky

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,19 +1,23 @@
 name: build
 
 on:
-  # Trigger the workflow on push or pull request,
-  # but only for the master branch
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  push: {}
+  pull_request: {}
+  # allow rebuilding without a push
+  workflow_dispatch: {}
+
 jobs:
   build:
     name: meta-rauc Build
-    runs-on: ubuntu-20.04
-    timeout-minutes: 720
+    # run on self-hosted runner for the main repo or if vars.BUILD_RUNS_ON is set
+    runs-on: >-
+      ${{
+        (vars.BUILD_RUNS_ON != ''  && fromJSON(vars.BUILD_RUNS_ON)) ||
+        (github.repository == 'rauc/meta-rauc' && fromJSON('["self-hosted", "forrest", "build"]')) ||
+        'ubuntu-20.04'
+      }}
+    # abort if it seems that we're rebuilding too much
+    timeout-minutes: 120
     steps:
       - name: Install required packages
         run: |
@@ -30,9 +34,16 @@ jobs:
         run: |
           source poky/oe-init-build-env build
           bitbake-layers add-layer ../meta-rauc
-          echo 'INHERIT += "rm_work"' >> conf/local.conf
+          if [ -f ~/.yocto/auto.conf ]; then
+            cp ~/.yocto/auto.conf conf/
+          else
+            echo 'SSTATE_MIRRORS = "file://.* https://github-runner.pengutronix.de/sstate-cache/PATH"' >> conf/auto.conf
+            echo 'BB_SIGNATURE_HANDLER = "OEBasicHash"' >> conf/auto.conf
+            echo 'BB_HASHSERVE = ""' >> conf/auto.conf
+            echo 'OPKGBUILDCMD = "opkg-build -Z gzip -a -1n"' >> conf/auto.conf
+            echo 'INHERIT += "rm_work"' >> conf/auto.conf
+          fi
           echo 'DISTRO_FEATURES:remove = "alsa bluetooth usbgadget usbhost wifi nfs zeroconf pci 3g nfc x11 opengl ptest wayland vulkan"' >> conf/local.conf
-          echo 'SSTATE_MIRRORS = "file://.* http://195.201.147.117/sstate-cache/PATH"' >> conf/local.conf
       - name: Build rauc, rauc-native
         run: |
           source poky/oe-init-build-env build
@@ -58,3 +69,13 @@ jobs:
           source poky/oe-init-build-env build
           bitbake-layers add-layer ../meta-openembedded/meta-python
           bitbake rauc-hawkbit
+      - name: Cache Data
+        env:
+          CACHE_KEY: ${{ secrets.YOCTO_CACHE_KEY }}
+        if: ${{ env.CACHE_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$CACHE_KEY" >> ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          rsync -rvx --ignore-existing build/downloads yocto-cache: || true
+          rsync -rvx --ignore-existing build/sstate-cache yocto-cache: || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: meta-rauc CI
+name: build
 
 on:
   # Trigger the workflow on push or pull request,


### PR DESCRIPTION
This is based on @hnez's [forrest runner](https://github.com/hnez/forrest), which provides ephemeral VMs while still allowing efficient and secure access to download and sstate caches.