### PR TITLE
bundle.bbclass: extend do_bundle[file-checksums]

### DIFF
--- a/classes-recipe/bundle.bbclass
+++ b/classes-recipe/bundle.bbclass
@@ -448,6 +448,7 @@ do_bundle() {
 }
 do_bundle[dirs] = "${B}"
 do_bundle[cleandirs] = "${B}"
+do_bundle[file-checksums] += "${RAUC_CERT_FILE}:False ${RAUC_KEY_FILE}:False"
 
 addtask bundle after do_configure
 


### PR DESCRIPTION
Rerun `do_bundle` task when `RAUC_CERT_FILE` or `RAUC_KEY_FILE` files have been changed on the disk.