### PR TITLE
styhead: .github/workflows/build: remove scheduled build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,6 @@ on:
   pull_request: {}
   # allow rebuilding without a push
   workflow_dispatch: {}
-  # pre-build sstate regularly
-  schedule:
-    - cron: '30 3 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
Scheduled builds only run for the main branch of a project, so configuring them on other release branches does not make a lot of sense.