### PR TITLE
.github/workflows/schedule-builds: Run scheduled jobs via workflow_dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,6 @@ on:
   pull_request: {}
   # allow rebuilding without a push
   workflow_dispatch: {}
-  # pre-build sstate regularly
-  schedule:
-    - cron: '30 3 * * *'
 
 jobs:
   build:

--- a/.github/workflows/schedule-builds.yml
+++ b/.github/workflows/schedule-builds.yml
@@ -1,0 +1,31 @@
+name: Schedule Builds
+
+on:
+  # allow rebuilding manually
+  workflow_dispatch:
+  # pre-build sstate regularly
+  schedule:
+    - cron: '30 3 * * *'
+
+jobs:
+  build:
+    name: Schedule Builds
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || vars.SCHEDULE_BUILDS }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Trigger master build
+        run: gh workflow run build --ref master
+
+      - name: Trigger styhead build
+        run: gh workflow run build --ref styhead
+
+      - name: Trigger scarthgap build
+        run: gh workflow run build --ref scarthgap
+
+      - name: Trigger kirkstone build
+        run: gh workflow run build --ref kirkstone


### PR DESCRIPTION
We currently only test the master branch on a regular schedule and not the different release branches (like e.g. scarthgap or styhead).

Also testing these other branches is complicated by the following detail in the GitHub action [documentation](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule):

> Scheduled workflows will only run on the default branch

This means we need some sort of workaround to run scheduled jobs on different branches. This commit adds a scheduled job on the master branch to trigger jobs on other branches via the `workflow_dispatch` event.

Build the master branch as well as all current release branches.

This PR is based on a very similar PR in meta-labgrid: https://github.com/labgrid-project/meta-labgrid/pull/57.

This PR depends on a few other things happening first:

- [x] Merge self-hosted runner and `workflow_dispatch` support for kirkstone https://github.com/rauc/meta-rauc/pull/354
- [x] Merge self-hosted runner and `workflow_dispatch` support for scarthgap https://github.com/rauc/meta-rauc/pull/355
- [x] Set the `SCHEDULE_BUILDS` GitHub action variable to a true-ish value.