### PR TITLE
[Scarthgap] bundle.bbclass: fix parsing with empty IMAGE_FSTYPES

### DIFF
--- a/classes-recipe/bundle.bbclass
+++ b/classes-recipe/bundle.bbclass
@@ -104,7 +104,8 @@ inherit nopackages
 PACKAGES = ""
 INHIBIT_DEFAULT_DEPS = "1"
 
-RAUC_IMAGE_FSTYPE ??= "${@(d.getVar('IMAGE_FSTYPES') or "").split()[0]}"
+# [""] is added to avoid "list index out of range" error with empty IMAGE_FSTYPES
+RAUC_IMAGE_FSTYPE ??= "${@(d.getVar('IMAGE_FSTYPES').split() + [""])[0]}"
 RAUC_IMAGE_FSTYPE[doc] = "Specifies the default file name extension to expect for collecting image artifacts. Defaults to first element set in IMAGE_FSTYPES."
 
 do_fetch[cleandirs] = "${S}"


### PR DESCRIPTION
If IMAGE_FSTYPES is empty, split() will return an empty array, resulting in an `IndexError: list index out of range` error during parsing. The `or ""` appears to be a previous attempt to handle this, but it is ineffective, and not actually needed: OE-core's bitbake.conf contains a default assignment for `IMAGE_FSTYPES`, so d.getVar() should always return a (possibly empty) string.

We have come across this issue in combination with meta-ti, which defines a multiconfig + additional machine for the Cortex-R5 core of TI SoCs. This machine is only used to build bootloader and firmware recipes, so IMAGE_FSTYPES is empty. As all recipes are parsed for all multiconfigs unless skipped explicitly, just the existence of the core-bundle-minimal recipe is enough to bring down the whole build in this configuration.

(cherry picked from commit a04182b8bab888d4fb675de7a4a2c879f3f587d9)