### PR TITLE
rauc-target: remove remnants of config handling

### DIFF
--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -1,6 +1,3 @@
-RAUC_KEYRING_FILE ??= "ca.cert.pem"
-RAUC_KEYRING_URI ??= "file://${RAUC_KEYRING_FILE}"
-
 RRECOMMENDS:${PN} += "virtual-rauc-conf"
 RRECOMMENDS:${PN} += "squashfs-tools"
 


### PR DESCRIPTION
All configuration was moved to the rauc-conf recipe in d51bab8f ("rauc: split package into 'rauc' for binary and 'rauc-conf' for configuration") but these lines were accidentally duplicated. Since they have no meaning in the rauc recipe, remove them.