### PR TITLE
.github/workflows/build: run on ubuntu 22.04 for python > 3.8.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,14 +14,14 @@ jobs:
       ${{
         (vars.BUILD_RUNS_ON != ''  && fromJSON(vars.BUILD_RUNS_ON)) ||
         (github.repository == 'rauc/meta-rauc' && fromJSON('["self-hosted", "forrest", "build"]')) ||
-        'ubuntu-20.04'
+        'ubuntu-22.04'
       }}
     # abort if it seems that we're rebuilding too much
     timeout-minutes: 120
     steps:
       - name: Install required packages
         run: |
-          sudo apt-get -q -y --no-install-recommends install diffstat
+          sudo apt-get -q -y --no-install-recommends install diffstat chrpath
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Since walnascar, the minimum required bitbake version will be 3.9.0:

> RuntimeError: Sorry, python 3.9.0 or later is required for this version of bitbake

This will allow continuing to run the GitHub actions on the GH-hosted runners.

Also, explicitly install 'chrpath', which does not seem to be part of the default installation anymore.