### PR TITLE
rauc: add PACKAGECONFIG option for composefs

### DIFF
--- a/recipes-core/rauc/rauc.inc
+++ b/recipes-core/rauc/rauc.inc
@@ -20,6 +20,7 @@ PACKAGECONFIG[streaming] = "-Dstreaming=true,-Dstreaming=false,libnl"
 PACKAGECONFIG[network] = "-Dnetwork=true,-Dnetwork=false,curl"
 PACKAGECONFIG[json]    = "-Djson=enabled,-Djson=disabled,json-glib"
 PACKAGECONFIG[gpt]     = "-Dgpt=enabled,-Dgpt=disabled,util-linux"
+PACKAGECONFIG[composefs] = "-Dcomposefs=enabled,-Dcomposefs=disabled,composefs"
 
 FILES:${PN}-dev += "\
   ${datadir}/dbus-1/interfaces/de.pengutronix.rauc.Installer.xml \


### PR DESCRIPTION
With RAUC v1.14, RAUC optionally supports composefs artifact repositories. This adds the necessary option to enable it.

It is disabled by default since the composefs recipe resides in meta-oe.