### PR TITLE
CI: run periodic builds for the walnascar branch

### DIFF
--- a/.github/workflows/schedule-builds.yml
+++ b/.github/workflows/schedule-builds.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Trigger master build
         run: gh workflow run build --ref master
 
+      - name: Trigger walnascar build
+        run: gh workflow run build --ref walnascar
+
       - name: Trigger styhead build
         run: gh workflow run build --ref styhead
 

--- a/README.rst
+++ b/README.rst
@@ -2,10 +2,12 @@
    :header-rows: 1
 
    * - master
+     - walnascar
      - styhead
      - scarthgap
      - kirkstone
    * - |gh_master|
+     - |gh_walnascar|
      - |gh_styhead|
      - |gh_scarthgap|
      - |gh_kirkstone|
@@ -239,6 +241,8 @@ VIII. References
    :target: https://github.com/rauc/meta-rauc/actions?query=event%3Aworkflow_dispatch+branch%3Ascarthgap++
 .. |gh_styhead| image:: https://github.com/rauc/meta-rauc/actions/workflows/build.yml/badge.svg?branch=styhead&event=workflow_dispatch
    :target: https://github.com/rauc/meta-rauc/actions?query=event%3Aworkflow_dispatch+branch%3Astyhead++
+.. |gh_walnascar| image:: https://github.com/rauc/meta-rauc/actions/workflows/build.yml/badge.svg?branch=walnascar&event=workflow_dispatch
+   :target: https://github.com/rauc/meta-rauc/actions?query=event%3Aworkflow_dispatch+branch%3Awalnascar++
 .. |gh_master| image:: https://github.com/rauc/meta-rauc/actions/workflows/build.yml/badge.svg?branch=master&event=workflow_dispatch
    :target: https://github.com/rauc/meta-rauc/actions?query=event%3Aworkflow_dispatch+branch%3Amaster++
 .. |Matrix| image:: https://img.shields.io/matrix/rauc:matrix.org?label=matrix%20chat


### PR DESCRIPTION
Support for the Yocto `walnascar` release has recently been added to `meta-rauc`.

Also run periodic builds for the release and display their status in the `README.rst`.