### PR TITLE
[walnascar] .github/workflows/build: build against the poky walnascar branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,9 @@ jobs:
         with:
           path: meta-rauc
       - name: Clone poky
-        run: git clone --shared --reference-if-able /srv/shared-git/poky.git -b master https://github.com/yoctoproject/poky.git
+        run: git clone --shared --reference-if-able /srv/shared-git/poky.git -b walnascar https://github.com/yoctoproject/poky.git
       - name: Clone meta-openembedded
-        run: git clone --shared --reference-if-able /srv/shared-git/meta-openembedded.git -b master https://github.com/openembedded/meta-openembedded.git
+        run: git clone --shared --reference-if-able /srv/shared-git/meta-openembedded.git -b walnascar https://github.com/openembedded/meta-openembedded.git
       - name: Initialize build directory
         run: |
           source poky/oe-init-build-env build


### PR DESCRIPTION
We must have missed this when splitting off the walnascar branch from master.

Now CI jobs have started failing due to this, because the layer compatible for poky master has changed to whinlatter from walnascar.