### PR TITLE
layer.conf: remove 'styhead' from LAYERSERIES_COMPAT

### DIFF
--- a/.github/workflows/schedule-builds.yml
+++ b/.github/workflows/schedule-builds.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Trigger walnascar build
         run: gh workflow run build --ref walnascar
 
-      - name: Trigger styhead build
-        run: gh workflow run build --ref styhead
-
       - name: Trigger scarthgap build
         run: gh workflow run build --ref scarthgap
 

--- a/README.rst
+++ b/README.rst
@@ -3,12 +3,10 @@
 
    * - master
      - walnascar
-     - styhead
      - scarthgap
      - kirkstone
    * - |gh_master|
      - |gh_walnascar|
-     - |gh_styhead|
      - |gh_scarthgap|
      - |gh_kirkstone|
 
@@ -239,8 +237,6 @@ VIII. References
    :target: https://github.com/rauc/meta-rauc/actions?query=event%3Aworkflow_dispatch+branch%3Akirkstone++
 .. |gh_scarthgap| image:: https://github.com/rauc/meta-rauc/actions/workflows/build.yml/badge.svg?branch=scarthgap&event=workflow_dispatch
    :target: https://github.com/rauc/meta-rauc/actions?query=event%3Aworkflow_dispatch+branch%3Ascarthgap++
-.. |gh_styhead| image:: https://github.com/rauc/meta-rauc/actions/workflows/build.yml/badge.svg?branch=styhead&event=workflow_dispatch
-   :target: https://github.com/rauc/meta-rauc/actions?query=event%3Aworkflow_dispatch+branch%3Astyhead++
 .. |gh_walnascar| image:: https://github.com/rauc/meta-rauc/actions/workflows/build.yml/badge.svg?branch=walnascar&event=workflow_dispatch
    :target: https://github.com/rauc/meta-rauc/actions?query=event%3Aworkflow_dispatch+branch%3Awalnascar++
 .. |gh_master| image:: https://github.com/rauc/meta-rauc/actions/workflows/build.yml/badge.svg?branch=master&event=workflow_dispatch

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,7 +17,7 @@ LAYERRECOMMENDS_rauc = "meta-python"
 # meta-filesystems is needed to build cascync with fuse support (the default)
 LAYERRECOMMENDS_rauc += "meta-filesystems"
 
-LAYERSERIES_COMPAT_rauc = "styhead walnascar"
+LAYERSERIES_COMPAT_rauc = "walnascar"
 
 # Sanity check for meta-rauc layer.
 # Setting SKIP_META_RAUC_FEATURE_CHECK to "1" would skip the bbappend files check.


### PR DESCRIPTION
The styhead release has gone out of support as of April 2025.
Time to remove support for it.
