### PR TITLE
[kirkstone] CI: install python3-setuptools instead of -distutils

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Install required packages
         run: |
-          sudo apt-get -q -y --no-install-recommends install diffstat python3-distutils
+          sudo apt-get -q -y --no-install-recommends install diffstat python3-setuptools
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The `python3-distutils` package is no longer available in Debian trixie and the [`python3-setuptools`](https://packages.debian.org/trixie/python3-setuptools) package provides a compatibility layer for it.
In Debian bookworm the python3-setuptools package depends on python3-distutils, so it will be installed either way.

Build on trixie without this change: https://github.com/pengutronix-test/meta-rauc/actions/runs/16957285236
Build on trixie with this change: https://github.com/pengutronix-test/meta-rauc/actions/runs/16957342688