### PR TITLE
layer.conf: remove 'walnascar' from LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,7 +17,7 @@ LAYERRECOMMENDS_rauc = "meta-python"
 # meta-filesystems is needed to build cascync with fuse support (the default)
 LAYERRECOMMENDS_rauc += "meta-filesystems"
 
-LAYERSERIES_COMPAT_rauc = "walnascar whinlatter"
+LAYERSERIES_COMPAT_rauc = "whinlatter"
 
 # Sanity check for meta-rauc layer.
 # Setting SKIP_META_RAUC_FEATURE_CHECK to "1" would skip the bbappend files check.


### PR DESCRIPTION
Commit 07cad39 ("rauc-git.inc: Remove S = "${WORKDIR}/git"") makes the master branch of meta-rauc incompatible with the walnascar release, since `S` is not set to the correct directory by default.

Remove it from the list of compatible layers.

---

This may be related to #387.

Edit:

Fixes #387