### PR TITLE
rauc.inc: add config for pkcs11_engine

### DIFF
--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -63,4 +63,4 @@ FILES:${PN}-service = "\
   ${nonarch_libdir}/systemd/catalog \
   "
 
-PACKAGECONFIG ??= "service network streaming json nocreate gpt"
+PACKAGECONFIG ??= "service network streaming json nocreate gpt engine"

--- a/recipes-core/rauc/rauc.inc
+++ b/recipes-core/rauc/rauc.inc
@@ -22,6 +22,7 @@ PACKAGECONFIG[json]    = "-Djson=enabled,-Djson=disabled,json-glib"
 PACKAGECONFIG[gpt]     = "-Dgpt=enabled,-Dgpt=disabled,util-linux"
 PACKAGECONFIG[composefs] = "-Dcomposefs=enabled,-Dcomposefs=disabled,composefs"
 PACKAGECONFIG[manpages] = "-Dmanpages=true,-Dmanpages=false,python3-sphinx-native python3-sphinx-rtd-theme-native"
+PACKAGECONFIG[engine] = "-Dpkcs11_engine=true,-Dpkcs11_engine=false,"
 
 FILES:${PN}-dev += "\
   ${datadir}/dbus-1/interfaces/de.pengutronix.rauc.Installer.xml \


### PR DESCRIPTION
Add a PACKAGECONFIG option to en-/disable pkcs11_engine named engine, because it disables engine support for openssl, not pkcs11 support. It is enabled by default to have no disruption to previous versions