### PR TITLE
[scarthgap] rauc: update to v1.15.2

### DIFF
--- a/recipes-core/rauc/nativesdk-rauc_1.15.2.bb
+++ b/recipes-core/rauc/nativesdk-rauc_1.15.2.bb
@@ -1,3 +1,3 @@
 require rauc.inc
-require rauc-1.15.1.inc
+require rauc-1.15.2.inc
 require nativesdk-rauc.inc

--- a/recipes-core/rauc/rauc-1.15.2.inc
+++ b/recipes-core/rauc/rauc-1.15.2.inc
@@ -1,5 +1,5 @@
 SRC_URI = "https://github.com/rauc/rauc/releases/download/v${PV}/rauc-${PV}.tar.xz"
 
-SRC_URI[sha256sum] = "603dafa5085b6b964c74d5f57a154a1489af2b415dd20c6ff1447815d02c094f"
+SRC_URI[sha256sum] = "127a24cde208c65b837ae978c695a00730f1094ee8b6c7d48cf58ef846eae340"
 
 UPSTREAM_CHECK_URI = "https://github.com/${BPN}/${BPN}/releases"

--- a/recipes-core/rauc/rauc-git.inc
+++ b/recipes-core/rauc/rauc-git.inc
@@ -2,10 +2,10 @@ SRC_URI = " \
   git://github.com/rauc/rauc.git;protocol=https;branch=master \
   "
 
-PV = "1.15.1+git${SRCPV}"
+PV = "1.15.2+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-SRCREV = "fac72b8347eed46f300d3a8a06e847ce1aa9d677"
+SRCREV = "4fb7c798d6ae412344fb8f8d310d773046af3441"
 
 RAUC_USE_DEVEL_VERSION[doc] = "Global switch to enable RAUC development (git) version."
 RAUC_USE_DEVEL_VERSION ??= "-1"

--- a/recipes-core/rauc/rauc-native_1.15.2.bb
+++ b/recipes-core/rauc/rauc-native_1.15.2.bb
@@ -1,3 +1,3 @@
 require rauc.inc
 require rauc-native.inc
-require rauc-1.15.1.inc
+require rauc-1.15.2.inc

--- a/recipes-core/rauc/rauc_1.15.2.bb
+++ b/recipes-core/rauc/rauc_1.15.2.bb
@@ -1,3 +1,3 @@
 require rauc.inc
 require rauc-target.inc
-require rauc-1.15.1.inc
+require rauc-1.15.2.inc


### PR DESCRIPTION
This release fixes CVE-2026-34155 "Improper Signing of Plain Bundles Exceeding 2 GiB".

See https://github.com/rauc/rauc/security/advisories/GHSA-6hj7-q844-m2hx for details.


(cherry picked from commit ab692cfb90d9dda982527e1bff898c1b8da76f6f)