### PR TITLE
rauc: fix git development version

### DIFF
--- a/recipes-core/rauc/rauc-git.inc
+++ b/recipes-core/rauc/rauc-git.inc
@@ -2,9 +2,9 @@ SRC_URI = " \
   git://github.com/rauc/rauc.git;protocol=https;branch=master \
   "
 
-PV = "1.15.2+git"
+PV = "1.15.1+git"
 
-SRCREV = "4fb7c798d6ae412344fb8f8d310d773046af3441"
+SRCREV = "63914bf8f4bdde4dc869d1999b289e91e43206b2"
 
 RAUC_USE_DEVEL_VERSION[doc] = "Global switch to enable RAUC development (git) version."
 RAUC_USE_DEVEL_VERSION ??= "-1"


### PR DESCRIPTION
The `SRCREV` pointed to the commit hash from the `stable-1.15` branch, while the `branch=` parameter pointed to the 'master' branch which will let the fetcher fail:

> ERROR: rauc-1.15.2+git-r0 do_fetch: Fetcher failure: Unable to find revision fb7c798d6ae412344fb8f8d310d773046af3441 in branch master even from upstream

Fix this by pointing to the latest master commit instead (which also includes the fix for CVE-2026-34155).

Since master has no direct history in common with 1.15.2, change the `PV` to `1.15.1+git`.

Fixes 9033f35b ("rauc: update to v1.15.2")

Fixes #422 