### PR TITLE
rauc: prepare for hermetic /usr/

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,12 @@ To use the optional casync feature with FUSE, you will also need:
 Migration Notes
 ===============
 
+Since **wrynose**, the ``rauc-conf`` recipe installs the ``system.conf`` and
+keyring file into ``/usr/lib/rauc`` to align with the 'hermetic ``/usr/``'
+policy followed by other OE components (like systemd).
+If you rely on the exact path where the ``system.conf`` is installed, you will
+need to adjust your integration.
+
 Since **scarthgap**, the platform configuration (system.conf, keyring, etc.) was
 moved to a separate ``rauc-conf.bb`` recipe to allow building the rauc package
 with ``TUNE_PKGARCH`` and have a clearer separation between the binary and the
@@ -63,7 +69,7 @@ at least the following steps are required:
 
      FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-   The ``rauc-conf`` recipe will install these files into ``/etc/rauc/`` by
+   The ``rauc-conf`` recipe will install these files into ``/usr/lib/rauc/`` by
    default.
 
    For information on how to write a proper RAUC system configuration, please

--- a/recipes-core/rauc/files/system.conf
+++ b/recipes-core/rauc/files/system.conf
@@ -1,6 +1,6 @@
-## This is an example RAUC system configuration. This file will be installed
-## into /etc/rauc/system.conf on your target and describes your system from the
-## perspective of the RAUC update service.
+## This is an example RAUC system configuration. This file will be be looked up
+## in {/etc,/run,/usr/lib}/rauc/system.conf (in that order) on your target and
+## describes your system from the perspective of the RAUC update service.
 ##
 ## Adapt and extend the below configuration to your needs and place it in the
 ## BSP layer of you project. Create a rauc .bbappend file that adds this file

--- a/recipes-core/rauc/rauc-conf.bb
+++ b/recipes-core/rauc/rauc-conf.bb
@@ -22,13 +22,15 @@ do_install () {
         if ! grep -q "^[^#]" ${UNPACKDIR}/system.conf; then
                 bbwarn "Please overwrite example system.conf with a project specific one!"
         fi
-        install -d ${D}${sysconfdir}/rauc
-        install -m 0644 ${UNPACKDIR}/system.conf ${D}${sysconfdir}/rauc/
+        install -d ${D}${nonarch_libdir}/rauc
+        install -m 0644 ${UNPACKDIR}/system.conf ${D}${nonarch_libdir}/rauc/
 
         # Warn if CA file was not overwritten
         if ! grep -q "^[^#]" ${UNPACKDIR}/${RAUC_KEYRING_FILE}; then
                 bbwarn "Please overwrite example ca.cert.pem with a project specific one, or set the RAUC_KEYRING_FILE variable with your file!"
         fi
-        install -d ${D}${sysconfdir}/rauc
-        install -m 0644 ${UNPACKDIR}/${RAUC_KEYRING_FILE} ${D}${sysconfdir}/rauc/
+        install -d ${D}${nonarch_libdir}/rauc
+        install -m 0644 ${UNPACKDIR}/${RAUC_KEYRING_FILE} ${D}${nonarch_libdir}/rauc/
 }
+
+FILES:${PN} += "${nonarch_libdir}/rauc"


### PR DESCRIPTION
The /etc directory is meant for 'local administrator' usage, which a distro build by OE isn't. For the same reason, several OE upstream packages (including systemd itself) already switch to installing into `/usr` instead of `/etc`.
For details on the concept, see [1].

RAUC supports reading the system.conf from `/usr/` since v1.13 [2].

For the next Yocto LTS release, we adapt to the new installation location, which might require migration for existing integrations. However, for most cases, no manual change should be required.

Add a note to the migration chapter to make users ware of this.

[1] https://0pointer.net/blog/fitting-everything-together.html
[2] https://github.com/rauc/rauc/pull/1557

Partly based on https://github.com/rauc/meta-rauc/commit/4cb7c47686d5dec9bacae6110f1bcaac57568691 ("rauc: prepare support for locating the config in /usr or /run").

Fixes #389 