### PR TITLE
rauc/rauc-target.inc: add a PACKAGECONFIG for mtd, enabled by default

### DIFF
--- a/recipes-core/rauc/rauc.inc
+++ b/recipes-core/rauc/rauc.inc
@@ -22,6 +22,7 @@ PACKAGECONFIG[json]    = "-Djson=enabled,-Djson=disabled,json-glib"
 PACKAGECONFIG[gpt]     = "-Dgpt=enabled,-Dgpt=disabled,util-linux"
 PACKAGECONFIG[composefs] = "-Dcomposefs=enabled,-Dcomposefs=disabled,composefs"
 PACKAGECONFIG[manpages] = "-Dmanpages=true,-Dmanpages=false,python3-sphinx-native python3-sphinx-rtd-theme-native"
+PACKAGECONFIG[mtd]     = ",,,mtd-utils"
 
 FILES:${PN}-dev += "\
   ${datadir}/dbus-1/interfaces/de.pengutronix.rauc.Installer.xml \


### PR DESCRIPTION
Using `nor` as a artifact's type is a very basic use-case and RAUC requires mtd-utils (flash_erase/flashcp) at runtime to support this. Add a new PACKAGECONFIG to support this while enabling it by default as it is a basic workflow.

Fixes #428