### PR TITLE
layer.conf: Correct name for meta-filesystems

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,7 +12,7 @@ BBFILE_PRIORITY_rauc = "6"
 LAYERDEPENDS_rauc = "core"
 
 # meta-filesystems is needed to build cascync with fuse support (the default)
-LAYERRECOMMENDS_rauc += "meta-filesystems"
+LAYERRECOMMENDS_rauc += "filesystems-layer"
 
 LAYERSERIES_COMPAT_rauc = "wrynose"
 


### PR DESCRIPTION
The collections name for meta-filesystems has always been "filesystems-layer" and not "meta-filesystems". Update the line here to match.