### PR TITLE
dt-utils: Allow downloads from Azure

### DIFF
--- a/recipes-bsp/dt-utils/dt-utils_2023.11.0.bb
+++ b/recipes-bsp/dt-utils/dt-utils_2023.11.0.bb
@@ -5,7 +5,7 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=18d902a0242c37a4604224b47d02f802"
 DEPENDS = "udev"
 
-SRC_URI = "http://www.pengutronix.de/software/dt-utils/download/${BPN}-${PV}.tar.xz"
+SRC_URI = "https://www.pengutronix.de/software/dt-utils/download/${BPN}-${PV}.tar.xz"
 SRC_URI[sha256sum] = "d224d941c076c143f43d59cd7c6e1c522926064a31ac34a67720632ddecb6b53"
 
 inherit meson pkgconfig gettext


### PR DESCRIPTION
The http SRC_URI hits a firewall rule on Azure VM
builds. Switch it to https.

Noted that sha256sum differs on same versions ...