### PR TITLE
rauc: allow RDEPENDS on dbus-broker via new VIRTUAL-RUNTIME_dbus variable

### DIFF
--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -54,7 +54,7 @@ FILES:${PN}-mark-good = "${systemd_unitdir}/system/rauc-mark-good.service ${sysc
 PACKAGES =+ "${PN}-service"
 SYSTEMD_SERVICE:${PN}-service = "${@bb.utils.contains('PACKAGECONFIG', 'service', 'rauc.service', '', d)}"
 SYSTEMD_PACKAGES += "${PN}-service"
-RDEPENDS:${PN}-service += "dbus"
+RDEPENDS:${PN}-service += "${VIRTUAL-RUNTIME_dbus}"
 
 FILES:${PN}-service = "\
   ${systemd_unitdir}/system/rauc.service \


### PR DESCRIPTION
The dbus-broker project is an alternative broker to the reference dbus implementation that is exclusively written for Linux systems, and makes use of many modern features provided by recent linux kernel releases.

Its use is transparent to RAUC, but the recipe currently hardcodes for the service a runtime dependency on `dbus`, which is the reference implementation.

The Whinlatter release introduced `${VIRTUAL-RUNTIME_dbus}`, which expands to the dbus broker being used.

Switch our recipe to use that. The build-time dependency on `dbus` remains as `dbus-broker` is, as the name implies, only a dbus broker.